### PR TITLE
[#266] Make Project input wider on project details page

### DIFF
--- a/web/js/projectDetails.js
+++ b/web/js/projectDetails.js
@@ -106,9 +106,9 @@ Ext.onReady(function(){
     var projectsPanel = new Ext.FormPanel({
         labelWidth: 100,
         frame: true,
-        width: 350,
+        width: 440,
         renderTo: 'content',
-        defaults: {width: 230},
+        defaults: {width: 320},
         items : [customerComboBox, projectComboBox]
     })
 });


### PR DESCRIPTION
shifted from 350 to 440, keeping the 120 width difference between the panel and combo box borders intact. 