### PR TITLE
[#335] Right align the delete-clone-template buttons in the bottomBox

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -738,15 +738,6 @@ var TaskPanel = Ext.extend(Ext.Panel, {
             },
             items:[
                 new Ext.Container({
-                    width: 186,
-                    layout: 'hbox',
-                    items:[
-                        this.deleteButton,
-                        this.cloneButton,
-                        this.createTemplateButton,
-                    ]
-                }),
-                new Ext.Container({
                     width: 460,
                     layout: 'hbox',
                     items:[
@@ -764,8 +755,19 @@ var TaskPanel = Ext.extend(Ext.Panel, {
                         this.onsiteCheckBox
                     ]
                 }),
+                new Ext.Container({
+                    layout: 'hbox',
+                    width: 186,
+                    style: 'float: right;',
+                    items: [
+                        this.deleteButton,
+                        this.cloneButton,
+                        this.createTemplateButton,
+                    ]
+                }),
             ]
         });
+
         this.items = [topBox, centerBox, bottomBox];
 
         /* call the superclass to preserve base class functionality */


### PR DESCRIPTION
A better alignment, and you can see the output here: 

![selection_245](https://cloud.githubusercontent.com/assets/4214481/20639599/62c95542-b3c8-11e6-90e2-5e13798ffec0.png)
