### PR TITLE
[#352] Pending holidays computes all the entire last journey of the e…

### DIFF
--- a/model/facade/action/GetPendingHolidayHoursAction.php
+++ b/model/facade/action/GetPendingHolidayHoursAction.php
@@ -137,26 +137,38 @@ class GetPendingHolidayHoursAction extends Action{
             {
 
                 // First of all, we clip the interval with the journey
-                $init = $journeyRow->getInitDate();
-                $end = $journeyRow->getEndDate();
+                $initJourney = $journeyRow->getInitDate();
+                $endJourney = $journeyRow->getEndDate();
 
-                if ($init<$this->init)
-                    $init = $this->init;
+                if ($initJourney < $this->init)
+                {
+                    $initYearDay = date_create($this->init->format("Y") . "-1-1");
+                    if ($initJourney < $initYearDay)
+                    {
+                        $initJourney = $initYearDay;
+                    }
+                }
 
-                if ($end>$this->end)
-                    $end = $this->end;
+                if ($endJourney > $this->end)
+                {
+                    $endYearDay = date_create($this->end->format("Y") . "-12-31");
+                    if ($endJourney > $endYearDay)
+                    {
+                        $endJourney = $endYearDay;
+                    }
+                }
 
                 // We get the difference in days...
-                $diffJourney = $init->diff($end);
+                $diffJourney = $initJourney->diff($endJourney);
                 // and with it and the journey, the worked hours (plus one day because it's a closed ending interval)
                 $workHours += ($diffJourney->days + 1)*($journeyRow->getJourney());
 
 
                 // We must check for leap years on the interval
-                $initYear = $init->format("Y");
+                $initYear = $initJourney->format("Y");
 
                 // Go from the init year to the end one
-                while ($initYear <= $end->format("Y"))
+                while ($initYear <= $endJourney->format("Y"))
                 {
 
                     // We check if the year is a leap one, and if february 29th is in the interval. There can be some useless checkings here

--- a/web/viewWorkingHoursResultsReport.php
+++ b/web/viewWorkingHoursResultsReport.php
@@ -219,7 +219,7 @@ Ext.onReady(function(){
                     if ($sid!="")
                         echo "&sid=" . $sid;
 
-                ?>&init=' + init.getFullYear() + "-01-01&end=" + end.getFullYear() + "-12-31";
+                ?>&init=' + init.getFullYear() + "-01-01&end=" + end.getFullYear() + "-" + (end.getMonth() + 1) + "-" + end.getDate();
 
                 pendingHoliday.load();
 


### PR DESCRIPTION
In model/facade/action/GetPendingHolidayHoursAction.php, removed the condition
which fix the end date of a journey interval to the end date passed as
parameter to the action DAO.

In case of the journey ends before the end of the year,
the pending hours will be prorated.

As working days always consider the entire journey ignoring the end date
interval ($this->end). This allows a correct and coherent count of the pending
holydays acording with the employee assigned journey.

Finally, In the /web/viewWorkingHoursResultsReport.php (UI) the interval for
the PendingHours request uses the submited data in the form instead of the end
date of the year.

Related issue: #352 