### PR TITLE
[#351] dont allow to save tasks without an assigned project

### DIFF
--- a/sql/update/force-non-empty-project.sql
+++ b/sql/update/force-non-empty-project.sql
@@ -1,7 +1,7 @@
 --
 -- Added the 'empty' project if there is tasks without project assigned
 --
-insert into project (description, areaid) 
+insert into project (description, areaid)
     select 'empty', 1 where exists (
         select * from task where projectid is null);
 
@@ -14,6 +14,5 @@ update task set projectid=(
 
 --
 -- projectid is not null
---
 --
 alter table task alter column projectid  set not null;

--- a/sql/update/force-non-empty-project.sql
+++ b/sql/update/force-non-empty-project.sql
@@ -1,0 +1,19 @@
+--
+-- Added the 'empty' project if there is tasks without project assigned
+--
+insert into project (description, areaid) 
+    select 'empty', 1 where exists (
+        select * from task where projectid is null);
+
+--
+-- Set already created task without project assigned to the 'empty' project
+--
+update task set projectid=(
+        select id from project where description = 'empty'
+    ) where projectid is null;
+
+--
+-- projectid is not null
+--
+--
+alter table task alter column projectid  set not null;

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -345,6 +345,7 @@ var TaskPanel = Ext.extend(Ext.Panel, {
             }),
             projectComboBox: new Ext.form.ComboBox({
                 parent: this,
+                allowBlank: false,
                 flex: 2,
                 store: new Ext.data.Store({
                     parent: this,

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -979,7 +979,9 @@ Ext.onReady(function(){
     function validateTasks() {
         var panels = tasksScrollArea.items;
         for(var panel=0; panel<panels.getCount(); panel++) {
-            if (!panels.get(panel).initTimeField.isValid() || !panels.get(panel).endTimeField.isValid()) {
+            if (!panels.get(panel).initTimeField.isValid()
+                || !panels.get(panel).endTimeField.isValid()
+                || !panels.get(panel).projectComboBox.isValid()) {
                 return false;
             }
         }

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -214,12 +214,17 @@
 
                 $taskVO->setUserId($user->getId());
 
-                $createTasks[] = $taskVO;
+                if (is_null($taskVO->getProjectId()))
+                {
+                    $string = "<return service='createTasks'><success>false</success><error id='4'>projectId is not valid</error></return>";
+                    break;
+                }
 
+                $createTasks[] = $taskVO;
             }
 
         } while ($parser->read());
-
+ 
 
         if (count($createTasks) >= 1)
             if (TasksFacade::CreateReports($createTasks) == -1)

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -224,7 +224,7 @@
             }
 
         } while ($parser->read());
- 
+
 
         if (count($createTasks) >= 1)
             if (TasksFacade::CreateReports($createTasks) == -1)


### PR DESCRIPTION
Related: #351 

DONE:
  * Frontend: the web UI shouldn't send tasks for save before the project field is set.
  * Backend: tasks without a project shouldn't be saved. This affects third-party apps using the web services.
  * forbid null entries in the projectid field of a task row.
  * set a default value for the previous entered tasks during the upgrade
  * if, there is tasks with no project assigned -> create a default "empty" project and assing the task to this project
