### PR TITLE
I318 Only list active projects in project details combo by default

### DIFF
--- a/web/js/projectDetails.js
+++ b/web/js/projectDetails.js
@@ -34,7 +34,8 @@ var projectComboBox = new Ext.form.ComboBox({
         autoSave: false, //if set true, changes will be sent instantly
         baseParams: {
             'order': 'description',
-            'active': 'false',
+            'active': '1',
+            'login': user,
         },
         filter: function(property, value, anyMatch, caseSensitive) {
             var fn;
@@ -51,6 +52,23 @@ var projectComboBox = new Ext.form.ComboBox({
         proxy: new Ext.data.HttpProxy({url: 'services/getProjectsService.php', method: 'GET'}),
         reader:new Ext.data.XmlReader({record: 'project', id:'id' }, projectRecord),
         remoteSort: false,
+        listeners: {
+            'load': function (store) {
+                var activeProjectsRecord = new projectRecord({
+                    id: -2,                  // some invalid id
+                    description: "Load all active projects",
+                    customerName: ""
+                });
+                var allProjectsRecord = new projectRecord({
+                    id: -1,                  // some invalid id
+                    description: "Load all projects",
+                    customerName: ""
+                });
+                store.add(activeProjectsRecord);
+                store.add(allProjectsRecord);
+                store.commitChanges();
+            }
+        }
     }),
     mode: 'local',
     valueField: 'id',
@@ -62,6 +80,20 @@ var projectComboBox = new Ext.form.ComboBox({
     '<tpl if="customerName">- {customerName}</tpl></div></tpl>',
     listeners: {
         'select': function (combo, record, index) {
+            if(record.data['id'] == -2) {
+                this.store.setBaseParam('active','1');
+                this.store.setBaseParam('login',null);
+                this.store.load();
+                this.clearValue();
+                return;
+            }
+            if(record.data['id'] == -1) {
+                this.store.setBaseParam('active',null);
+                this.store.setBaseParam('login',null);
+                this.store.load();
+                this.clearValue();
+                return;
+            }
             customerId = null;
             selectText = record.data['description'];
 

--- a/web/projectDetails.php
+++ b/web/projectDetails.php
@@ -29,6 +29,13 @@ include_once("include/header.php");
 include_once("include/sidebar.php");
 include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
 $user = $_SESSION['user'];
+
+//output vars as JS code
+echo "<!-- Global variables extracted from the PHP side -->\n";
+echo "<script type='text/javascript'>\n";
+echo "var user = '" . $user->getLogin() . "';\n";
+echo "</script>\n";
+
 ?>
 <script src="js/include/sessionTracker.js"></script>
 <script type="text/javascript" src="js/include/ExportableGridPanel.js"></script>


### PR DESCRIPTION
* Defined the 'user' variable in the scope of the web/js/projectDetails.js JS
  code
* Modified the default behavior of the 'Project' combobox in
  projectDetails.php to: show only the active projects for the logged user
* Added 'Load all active projects' entry in the 'Project' combobox in
  projectDetails.php
* Added 'Load all projects' entry in the 'Project' combobox in
  projectDetails.php

Make references to the #318 issue.