### PR TITLE
I326 Redirect to original URL after successful login

### DIFF
--- a/web/js/include/sessionTracker.js
+++ b/web/js/include/sessionTracker.js
@@ -25,7 +25,7 @@ function checkIfSessionExists() {
         failure: function (response) {
             Ext.MessageBox.confirm('Session Expired', 'Do you want to login again?', function(btn){
                 if(btn === 'yes'){
-                    window.location.href = "login.php";
+                    window.location.reload();
                 }
             });
         }


### PR DESCRIPTION
The relogin modal dialog reloads the page instead of perform a redirection to the login page. If there is not a valid session the user will be finally redirected to the login page but passing the current loaded URL as parameter to come back again after the login success.

Refers to #326