### PR TITLE
Lock tasks before date

### DIFF
--- a/model/dao/ConfigDAO/ConfigDAO.php
+++ b/model/dao/ConfigDAO/ConfigDAO.php
@@ -92,9 +92,14 @@ abstract class ConfigDAO extends BaseDAO {
      *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
+     * @param boolean $dateLimitEnabled Enable of disable a limit date for tasks,
+     *        so tasks before that date would be blocked.
+     * @param DateTime $date Tasks before this date would be blocked if
+     *        $dateLimitEnabled is set.
      * @return boolean returns wether changes were saved or not.
      */
-    public abstract function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays);
+    public abstract function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays,
+            $dateLimitEnabled, $date);
 
     /** User value object constructor for PostgreSQL.
      *

--- a/model/dao/ConfigDAO/ConfigDAO.php
+++ b/model/dao/ConfigDAO/ConfigDAO.php
@@ -72,10 +72,14 @@ abstract class ConfigDAO extends BaseDAO {
      * Return all the values implicated in the configuration of task block by
      * date.
      *
-     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     * @return array "dayLimitEnabled" returns whether task block by day limit is
      *         enabled or not.
      *         "numberOfDays" returns the number of days configured as day
-     *         limit.
+     *         limit. May be null.
+     *         "dateLimitEnabled" returns whether task block by date is enabled
+     *         or not.
+     *         "date" returns the date before which tasks may not be edited. May
+     *         be null.
      */
     public abstract function getTaskBlockConfiguration();
 

--- a/model/dao/ConfigDAO/ConfigDAO.php
+++ b/model/dao/ConfigDAO/ConfigDAO.php
@@ -72,8 +72,9 @@ abstract class ConfigDAO extends BaseDAO {
      * Return all the values implicated in the configuration of task block by
      * date.
      *
-     * @return array "enabled" returns wether task block is enabled or not.
-     *         "numberOfDays" returns the number of days configured as time
+     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     *         enabled or not.
+     *         "numberOfDays" returns the number of days configured as day
      *         limit.
      */
     public abstract function getTaskBlockConfiguration();
@@ -83,12 +84,13 @@ abstract class ConfigDAO extends BaseDAO {
      * Change PhpReport configuration to allow or prevent writing tasks based on
      * the date of those tasks.
      *
-     * @param boolean $enabled Enable of disable the task block feature.
+     * @param boolean $dayLimitEnabled Enable of disable a day limit for tasks,
+     *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
      * @return boolean returns wether changes were saved or not.
      */
-    public abstract function setTaskBlockConfiguration($enabled, $numberOfDays);
+    public abstract function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays);
 
     /** User value object constructor for PostgreSQL.
      *

--- a/model/dao/ConfigDAO/PostgreSQLConfigDAO.php
+++ b/model/dao/ConfigDAO/PostgreSQLConfigDAO.php
@@ -74,14 +74,14 @@ class PostgreSQLConfigDAO extends ConfigDAO {
      *         written or not.
      */
     public function isWriteAllowedForDate(DateTime $date){
-        $sql = "SELECT block_tasks_by_time_enabled FROM config";
-        $enabled = $this->execute($sql);
-        $enabled = (strtolower($enabled[0]) == "t");
+        $sql = "SELECT block_tasks_by_day_limit_enabled FROM config";
+        $dayLimitEnabled = $this->execute($sql);
+        $dayLimitEnabled = (strtolower($dayLimitEnabled[0]) == "t");
 
-        $sql = "SELECT block_tasks_by_time_number_of_days FROM config";
+        $sql = "SELECT block_tasks_by_day_limit_number_of_days FROM config";
         $days = $this->execute($sql);
 
-        if(!$enabled || is_null($days[0]) || $days[0] == 0) {
+        if(!$dayLimitEnabled || is_null($days[0]) || $days[0] == 0) {
             return true;
         }
 
@@ -99,19 +99,20 @@ class PostgreSQLConfigDAO extends ConfigDAO {
      * Return all the values implicated in the configuration of task block by
      * date.
      *
-     * @return array "enabled" returns wether task block is enabled or not.
-     *         "numberOfDays" returns the number of days configured as time
+     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     *         enabled or not.
+     *         "numberOfDays" returns the number of days configured as day
      *         limit.
      */
     public function getTaskBlockConfiguration() {
-        $sql = "SELECT block_tasks_by_time_enabled FROM config";
-        $enabled = $this->execute($sql);
+        $sql = "SELECT block_tasks_by_day_limit_enabled FROM config";
+        $dayLimitEnabled = $this->execute($sql);
 
-        $sql = "SELECT block_tasks_by_time_number_of_days FROM config";
+        $sql = "SELECT block_tasks_by_day_limit_number_of_days FROM config";
         $days = $this->execute($sql);
 
         return array(
-            "enabled" => (strtolower($enabled[0]) == "t"),
+            "dayLimitEnabled" => (strtolower($dayLimitEnabled[0]) == "t"),
             "numberOfDays" => $days[0]);
     }
 
@@ -120,17 +121,18 @@ class PostgreSQLConfigDAO extends ConfigDAO {
      * Change PhpReport configuration to allow or prevent writing tasks based on
      * the date of those tasks.
      *
-     * @param boolean $enabled Enable of disable the task block feature.
+     * @param boolean $dayLimitEnabled Enable of disable a day limit for tasks,
+     *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
      * @return boolean returns wether changes were saved or not.
      */
-    public function setTaskBlockConfiguration($enabled, $numberOfDays) {
+    public function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays) {
         $sql = "UPDATE config SET " .
-                "block_tasks_by_time_number_of_days =" .
+                "block_tasks_by_day_limit_number_of_days =" .
                 DBPostgres::checkNull($numberOfDays) . "," .
-                "block_tasks_by_time_enabled = " .
-                DBPostgres::boolToString($enabled);
+                "block_tasks_by_day_limit_enabled = " .
+                DBPostgres::boolToString($dayLimitEnabled);
 
         $res = pg_query($this->connect, $sql);
 

--- a/model/dao/ConfigDAO/PostgreSQLConfigDAO.php
+++ b/model/dao/ConfigDAO/PostgreSQLConfigDAO.php
@@ -144,14 +144,23 @@ class PostgreSQLConfigDAO extends ConfigDAO {
      *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
+     * @param boolean $dateLimitEnabled Enable of disable a limit date for tasks,
+     *        so tasks before that date would be blocked.
+     * @param DateTime $date Tasks before this date would be blocked if
+     *        $dateLimitEnabled is set.
      * @return boolean returns wether changes were saved or not.
      */
-    public function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays) {
+    public function setTaskBlockConfiguration($dayLimitEnabled, $numberOfDays,
+            $dateLimitEnabled, $date) {
         $sql = "UPDATE config SET " .
+                "block_tasks_by_day_limit_enabled = " .
+                DBPostgres::boolToString($dayLimitEnabled) . "," .
                 "block_tasks_by_day_limit_number_of_days =" .
                 DBPostgres::checkNull($numberOfDays) . "," .
-                "block_tasks_by_day_limit_enabled = " .
-                DBPostgres::boolToString($dayLimitEnabled);
+                "block_tasks_by_date_enabled = " .
+                DBPostgres::boolToString($dateLimitEnabled) . "," .
+                "block_tasks_by_date_date = " .
+                DBPostgres::formatDate($date);
 
         $res = pg_query($this->connect, $sql);
 

--- a/model/facade/TasksFacade.php
+++ b/model/facade/TasksFacade.php
@@ -554,11 +554,17 @@ abstract class TasksFacade {
      *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
+     * @param boolean $dateLimitEnabled Enable of disable a limit date for tasks,
+     *        so tasks before that date would be blocked.
+     * @param DateTime $date Tasks before this date would be blocked if
+     *        $dateLimitEnabled is set.
      * @return boolean returns wether changes were saved or not.
      */
-    static function SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays) {
+    static function SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays,
+            $dateLimitEnabled, $date) {
 
-        $action = new SetTaskBlockConfigurationAction($dayLimitEnabled, $numberOfDays);
+        $action = new SetTaskBlockConfigurationAction($dayLimitEnabled,
+                $numberOfDays, $dateLimitEnabled, $date);
         return $action->execute();
     }
 

--- a/model/facade/TasksFacade.php
+++ b/model/facade/TasksFacade.php
@@ -567,10 +567,14 @@ abstract class TasksFacade {
      * Return all the values implicated in the configuration of task block by
      * date.
      *
-     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     * @return array "dayLimitEnabled" returns whether task block by day limit is
      *         enabled or not.
      *         "numberOfDays" returns the number of days configured as day
-     *         limit.
+     *         limit. May be null.
+     *         "dateLimitEnabled" returns whether task block by date is enabled
+     *         or not.
+     *         "date" returns the date before which tasks may not be edited. May
+     *         be null.
      */
     static function GetTaskBlockConfiguration() {
 

--- a/model/facade/TasksFacade.php
+++ b/model/facade/TasksFacade.php
@@ -550,14 +550,15 @@ abstract class TasksFacade {
      * Change PhpReport configuration to allow or prevent writing tasks based on
      * the date of those tasks.
      *
-     * @param boolean $enabled Enable of disable the task block feature.
+     * @param boolean $dayLimitEnabled Enable of disable a day limit for tasks,
+     *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
      * @return boolean returns wether changes were saved or not.
      */
-    static function SetTaskBlockConfiguration($enabled, $numberOfDays) {
+    static function SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays) {
 
-        $action = new SetTaskBlockConfigurationAction($enabled, $numberOfDays);
+        $action = new SetTaskBlockConfigurationAction($dayLimitEnabled, $numberOfDays);
         return $action->execute();
     }
 
@@ -566,8 +567,9 @@ abstract class TasksFacade {
      * Return all the values implicated in the configuration of task block by
      * date.
      *
-     * @return array "enabled" returns wether task block is enabled or not.
-     *         "numberOfDays" returns the number of days configured as time
+     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     *         enabled or not.
+     *         "numberOfDays" returns the number of days configured as day
      *         limit.
      */
     static function GetTaskBlockConfiguration() {

--- a/model/facade/action/GetTaskBlockConfigurationAction.php
+++ b/model/facade/action/GetTaskBlockConfigurationAction.php
@@ -58,8 +58,9 @@ class GetTaskBlockConfigurationAction extends Action {
      * This is the function that contains the code that checks the configuration
      * on the DB.
      *
-     * @return array "enabled" returns wether task block is enabled or not.
-     *         "numberOfDays" returns the number of days configured as time
+     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     *         enabled or not.
+     *         "numberOfDays" returns the number of days configured as day
      *         limit.
      */
     protected function doExecute() {

--- a/model/facade/action/GetTaskBlockConfigurationAction.php
+++ b/model/facade/action/GetTaskBlockConfigurationAction.php
@@ -58,10 +58,14 @@ class GetTaskBlockConfigurationAction extends Action {
      * This is the function that contains the code that checks the configuration
      * on the DB.
      *
-     * @return array "dayLimitEnabled" returns wether task block by day limit is
+     * @return array "dayLimitEnabled" returns whether task block by day limit is
      *         enabled or not.
      *         "numberOfDays" returns the number of days configured as day
-     *         limit.
+     *         limit. May be null.
+     *         "dateLimitEnabled" returns whether task block by date is enabled
+     *         or not.
+     *         "date" returns the date before which tasks may not be edited. May
+     *         be null.
      */
     protected function doExecute() {
         $configDao = DAOFactory::getConfigDAO();

--- a/model/facade/action/SetTaskBlockConfigurationAction.php
+++ b/model/facade/action/SetTaskBlockConfigurationAction.php
@@ -43,13 +43,13 @@ include_once(PHPREPORT_ROOT . '/model/dao/DAOFactory.php');
  */
 class SetTaskBlockConfigurationAction extends Action {
 
-    /** Enabled/disabled value
+    /** Day limit enabled/disabled
      *
-     * Enable of disable the task block feature.
+     * Enable of disable a day limit for tasks.
      *
      * @var boolean
      */
-    private $enabled;
+    private $dayLimitEnabled;
 
     /** Number of days
      *
@@ -63,12 +63,13 @@ class SetTaskBlockConfigurationAction extends Action {
      *
      * This is just the constructor of this action.
      *
-     * @param boolean $enabled Enable of disable the task block feature.
+     * @param boolean $dayLimitEnabled Enable of disable a day limit for tasks,
+     *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
      */
-    public function __construct($enabled, $numberOfDays) {
-        $this->enabled = $enabled;
+    public function __construct($dayLimitEnabled, $numberOfDays) {
+        $this->dayLimitEnabled = $dayLimitEnabled;
         $this->numberOfDays = $numberOfDays;
         $this->preActionParameter = "SET_TASK_BLOCK_CONFIGURATION_PREACTION";
         $this->postActionParameter = "SET_TASK_BLOCK_CONFIGURATION_POSTACTION";
@@ -83,7 +84,7 @@ class SetTaskBlockConfigurationAction extends Action {
      */
     protected function doExecute() {
         $configDao = DAOFactory::getConfigDAO();
-        return $configDao->setTaskBlockConfiguration($this->enabled,
+        return $configDao->setTaskBlockConfiguration($this->dayLimitEnabled,
                 $this->numberOfDays);
     }
 

--- a/model/facade/action/SetTaskBlockConfigurationAction.php
+++ b/model/facade/action/SetTaskBlockConfigurationAction.php
@@ -59,6 +59,22 @@ class SetTaskBlockConfigurationAction extends Action {
      */
     private $numberOfDays;
 
+    /** Date limit enabled/disabled
+     *
+     * Enable of disable a date before which tasks cannot be written.
+     *
+     * @var boolean
+     */
+    private $dateLimitEnabled;
+
+    /** Limit date.
+     *
+     * Date before which tasks cannot be written.
+     *
+     * @var boolean
+     */
+    private $date;
+
     /** SetTaskBlockConfigurationAction constructor.
      *
      * This is just the constructor of this action.
@@ -67,10 +83,18 @@ class SetTaskBlockConfigurationAction extends Action {
      *        so tasks older than a certain number of days would be blocked.
      * @param int $numberOfDays Set the number of days in the past when tasks
      *        tasks cannot be altered.
+     * @param boolean $dateLimitEnabled Enable of disable a limit date for tasks,
+     *        so tasks before that date would be blocked.
+     * @param DateTime $date Tasks before this date would be blocked if
+     *        $dateLimitEnabled is set.
+     * @return boolean returns wether changes were saved or not.
      */
-    public function __construct($dayLimitEnabled, $numberOfDays) {
+    public function __construct($dayLimitEnabled, $numberOfDays,
+            $dateLimitEnabled, $date) {
         $this->dayLimitEnabled = $dayLimitEnabled;
         $this->numberOfDays = $numberOfDays;
+        $this->dateLimitEnabled = $dateLimitEnabled;
+        $this->date = $date;
         $this->preActionParameter = "SET_TASK_BLOCK_CONFIGURATION_PREACTION";
         $this->postActionParameter = "SET_TASK_BLOCK_CONFIGURATION_POSTACTION";
 
@@ -85,7 +109,7 @@ class SetTaskBlockConfigurationAction extends Action {
     protected function doExecute() {
         $configDao = DAOFactory::getConfigDAO();
         return $configDao->setTaskBlockConfiguration($this->dayLimitEnabled,
-                $this->numberOfDays);
+                $this->numberOfDays, $this->dateLimitEnabled, $this->date);
     }
 
 }

--- a/sql/update/add-date-block-to-config.sql
+++ b/sql/update/add-date-block-to-config.sql
@@ -5,3 +5,13 @@
 
 ALTER TABLE config RENAME COLUMN block_tasks_by_time_enabled TO block_tasks_by_day_limit_enabled;
 ALTER TABLE config RENAME COLUMN block_tasks_by_time_number_of_days TO block_tasks_by_day_limit_number_of_days;
+
+--
+-- Add new columns in config table:
+-- * block_tasks_by_date_enabled: enable/disable the block of tasks by date.
+-- * block_tasks_by_date_date: task before which tasks be blocked.
+--
+
+ALTER TABLE config ADD COLUMN block_tasks_by_date_enabled BOOLEAN
+    NOT NULL DEFAULT false;
+ALTER TABLE config ADD COLUMN block_tasks_by_date_date DATE;

--- a/sql/update/add-date-block-to-config.sql
+++ b/sql/update/add-date-block-to-config.sql
@@ -1,0 +1,7 @@
+--
+-- Rename existing task block columns; change block_tasks_by_time_ prefix to
+-- block_tasks_by_day_limit_.
+--
+
+ALTER TABLE config RENAME COLUMN block_tasks_by_time_enabled TO block_tasks_by_day_limit_enabled;
+ALTER TABLE config RENAME COLUMN block_tasks_by_time_number_of_days TO block_tasks_by_day_limit_number_of_days;

--- a/sql/update/all.sql
+++ b/sql/update/all.sql
@@ -175,3 +175,13 @@ alter table task alter column projectid  set not null;
 
 ALTER TABLE config RENAME COLUMN block_tasks_by_time_enabled TO block_tasks_by_day_limit_enabled;
 ALTER TABLE config RENAME COLUMN block_tasks_by_time_number_of_days TO block_tasks_by_day_limit_number_of_days;
+
+--
+-- Add new columns in config table:
+-- * block_tasks_by_date_enabled: enable/disable the block of tasks by date.
+-- * block_tasks_by_date_date: task before which tasks be blocked.
+--
+
+ALTER TABLE config ADD COLUMN block_tasks_by_date_enabled BOOLEAN
+    NOT NULL DEFAULT false;
+ALTER TABLE config ADD COLUMN block_tasks_by_date_date DATE;

--- a/sql/update/all.sql
+++ b/sql/update/all.sql
@@ -167,3 +167,11 @@ UPDATE config SET version='2.17';
 --
 
 alter table task alter column projectid  set not null;
+
+--
+-- Rename existing task block columns; change block_tasks_by_time_ prefix to
+-- block_tasks_by_day_limit_.
+--
+
+ALTER TABLE config RENAME COLUMN block_tasks_by_time_enabled TO block_tasks_by_day_limit_enabled;
+ALTER TABLE config RENAME COLUMN block_tasks_by_time_number_of_days TO block_tasks_by_day_limit_number_of_days;

--- a/web/settings.php
+++ b/web/settings.php
@@ -37,14 +37,23 @@ include_once(PHPREPORT_ROOT . '/model/facade/TasksFacade.php');
 /* There are POST data: we try to save the settings */
 if(isset($_POST["numberOfDays"])) {
     $dayLimitEnabled = false;
+    $dateLimitEnabled = false;
     $numberOfDays = null;
+    $date = null;
     if(isset($_POST["dayLimitEnabled"])) {
         $dayLimitEnabled = true;
+    }
+    if(isset($_POST["dateLimitEnabled"])) {
+        $dateLimitEnabled = true;
     }
     if(!empty($_POST["numberOfDays"])) {
         $numberOfDays = $_POST["numberOfDays"];
     }
-    $saved = TasksFacade::SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays);
+    if(!empty($_POST["date"])) {
+        $date = date_create($_POST["date"]);
+    }
+    $saved = TasksFacade::SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays,
+            $dateLimitEnabled, $date);
 }
 
 /* Include the generic header and sidebar*/
@@ -58,11 +67,19 @@ $config = TasksFacade::GetTaskBlockConfiguration();
 echo '<script type="text/javascript">';
 echo 'var dayLimitEnabled = ';
 echo $config['dayLimitEnabled']?'true; ':'false; ';
+echo 'var dateLimitEnabled = ';
+echo $config['dateLimitEnabled']?'true; ':'false; ';
 if($config['numberOfDays'] != null) {
     echo 'var numberOfDays = ' . $config['numberOfDays'] . ';';
 }
 else {
     echo 'var numberOfDays;';
+}
+if(!is_null($config['date'])) {
+    echo "var date = Date.parseDate('" . $config['date']->format('Y-m-d') . "', 'Y-m-d');";
+}
+else {
+    echo "var date = '';";
 }
 if (isset($saved)) {
     echo 'var saved = true; ';
@@ -108,7 +125,7 @@ Ext.onReady(function () {
         width: 250,
         defaults: {width: 130},
         items: [{
-                fieldLabel: 'Block enabled',
+                fieldLabel: 'Day block enabled',
                 xtype: 'checkbox',
                 name: 'dayLimitEnabled',
                 checked: dayLimitEnabled,
@@ -117,6 +134,19 @@ Ext.onReady(function () {
                 xtype: 'numberfield',
                 name: 'numberOfDays',
                 value: numberOfDays,
+            },{
+                fieldLabel: 'Date block enabled',
+                xtype: 'checkbox',
+                name: 'dateLimitEnabled',
+                checked: dateLimitEnabled,
+            },{
+                fieldLabel: 'Date',
+                xtype: 'datefieldplus',
+                format: 'd/m/Y',
+                startDay: 1,
+                useQuickTips: false,
+                name: 'date',
+                value: date,
             }
         ],
         buttons: [{

--- a/web/settings.php
+++ b/web/settings.php
@@ -36,15 +36,15 @@ include_once(PHPREPORT_ROOT . '/model/facade/TasksFacade.php');
 
 /* There are POST data: we try to save the settings */
 if(isset($_POST["numberOfDays"])) {
-    $enabled = false;
+    $dayLimitEnabled = false;
     $numberOfDays = null;
-    if(isset($_POST["enabled"])) {
-        $enabled = true;
+    if(isset($_POST["dayLimitEnabled"])) {
+        $dayLimitEnabled = true;
     }
     if(!empty($_POST["numberOfDays"])) {
         $numberOfDays = $_POST["numberOfDays"];
     }
-    $saved = TasksFacade::SetTaskBlockConfiguration($enabled, $numberOfDays);
+    $saved = TasksFacade::SetTaskBlockConfiguration($dayLimitEnabled, $numberOfDays);
 }
 
 /* Include the generic header and sidebar*/
@@ -56,8 +56,8 @@ include("include/sidebar.php");
 $config = TasksFacade::GetTaskBlockConfiguration();
 
 echo '<script type="text/javascript">';
-echo 'var enabled = ';
-echo $config['enabled']?'true; ':'false; ';
+echo 'var dayLimitEnabled = ';
+echo $config['dayLimitEnabled']?'true; ':'false; ';
 if($config['numberOfDays'] != null) {
     echo 'var numberOfDays = ' . $config['numberOfDays'] . ';';
 }
@@ -110,8 +110,8 @@ Ext.onReady(function () {
         items: [{
                 fieldLabel: 'Block enabled',
                 xtype: 'checkbox',
-                name: 'enabled',
-                checked: enabled,
+                name: 'dayLimitEnabled',
+                checked: dayLimitEnabled,
             },{
                 fieldLabel: 'Number of days',
                 xtype: 'numberfield',


### PR DESCRIPTION
Fixes #345.

Adds new fields to the database, means to retrieve and save their values from the frontend and reimplement `ConfigDAO::isWriteAllowedForDate` to take into account both a date and a number of days to block tasks.

Feedback is appreciated, specially on how to name the related fields to prevent confusion.