### PR TITLE
Added success block to hide MessageBox in case it exists

### DIFF
--- a/web/js/include/sessionTracker.js
+++ b/web/js/include/sessionTracker.js
@@ -28,6 +28,9 @@ function checkIfSessionExists() {
                     window.location.reload();
                 }
             });
+        },
+        success: function (response) {
+            Ext.MessageBox.hide();
         }
     });
 


### PR DESCRIPTION
I've been testing this on my local deployment.

Adding the `success` action is hiding the MessageBox in case it exists.