### PR TITLE
Moved copy tasks from date to the actions box

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1377,7 +1377,7 @@ Ext.onReady(function(){
         frame:true,
         title: 'Actions',
         defaults: {
-            width: 190,
+            style: 'padding-bottom: 6px',
         },
         items: [
             new Ext.form.Label({
@@ -1387,17 +1387,17 @@ Ext.onReady(function(){
                 layout: 'hbox',
                 items: [newTaskButton, saveButton],
             }),
-            new Ext.menu.Separator(),
+
             new Ext.form.Label({
                 text: 'Panels'
             }),
             expandCollapseAllPanel,
-            new Ext.menu.Separator(),
+
             new Ext.form.Label({
                 text: 'Copy tasks from date'
             }),
             cloningPanel,
-            new Ext.menu.Separator(),
+
             new Ext.form.Label({
                 text: 'Templates'
             }),

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1048,30 +1048,23 @@ Ext.onReady(function(){
 
     // Cloning Panel
     var cloningPanel = new Ext.FormPanel({
-        width: 204,
-        height: 65,
-        renderTo: Ext.get('calendarpanel'),
-        frame:true,
-        layout: {
-            type: 'vbox',
-            align: 'center',
-        },
+        layout: 'hbox',
         header: false,
         items: [
             {
                 name: 'cloneDate',
                 id: 'cloneDate',
                 hideLabel: true,
-                width: 160,
+                flex: 3,
                 xtype: 'datefieldplus',
                 format: 'd/m/Y',
                 value: lastTaskDate,
                 allowBlank: false,
                 startDay: 1,
             }, new Ext.Button({
-                text:'Copy tasks from selected date',
-                width: 60,
-                margins: "7px 0 0 0px",
+                text:'Copy',
+                margins: "0px 0 0 0px",
+                flex: 1,
                 handler: function() {
                     if (Ext.getCmp('cloneDate').isValid())
                     {
@@ -1399,6 +1392,11 @@ Ext.onReady(function(){
                 text: 'Panels'
             }),
             expandCollapseAllPanel,
+            new Ext.menu.Separator(),
+            new Ext.form.Label({
+                text: 'Copy tasks from date'
+            }),
+            cloningPanel,
             new Ext.menu.Separator(),
             new Ext.form.Label({
                 text: 'Templates'


### PR DESCRIPTION
This way, we are saving more vertical space.

Changes:

 * Added a new section at the actions box
 * Changed layout into an hbox
 * Adjusted width and margins of both elements
 * Shortened button text