### PR TITLE
Disable "copy tasks from date" feature in blocked dates.

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1060,11 +1060,12 @@ Ext.onReady(function(){
                 format: 'd/m/Y',
                 value: lastTaskDate,
                 allowBlank: false,
-                startDay: 1,
+                disabled: forbidden,
             }, new Ext.Button({
                 text:'Copy',
                 margins: "0px 0 0 0px",
                 flex: 1,
+                disabled: forbidden,
                 handler: function() {
                     if (Ext.getCmp('cloneDate').isValid())
                     {


### PR DESCRIPTION
`startDay` attribute was removed just because it's unnecessary.

Fix #259.