### PR TITLE
Fix wrong length of "full day task" on new users' first day.

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1203,6 +1203,8 @@ Ext.onReady(function(){
                         window.setTimeout(Ext.getCmp('fullDayTaskButton').handler, 100);
                         return;
                     }
+                    if (currentJourney == 0)
+                        return;
 
                     removeFreshEmptyTask();
 
@@ -1233,6 +1235,8 @@ Ext.onReady(function(){
                         window.setTimeout(Ext.getCmp('fullHolidayTaskButton').handler, 100);
                         return;
                     }
+                    if (currentJourney == 0)
+                        return;
 
                     removeFreshEmptyTask();
 

--- a/web/tasks.php
+++ b/web/tasks.php
@@ -69,7 +69,8 @@ else {
 $lastTaskDate = TasksFacade::getLastTaskDate($user, $date);
 if($lastTaskDate == NULL) {
     //defaults to the day before $date
-    $lastTaskDate = $date->sub(new DateInterval('P1D'));
+    $lastTaskDate = clone $date;
+    $lastTaskDate->sub(new DateInterval('P1D'));
 }
 $lastTaskDate = $lastTaskDate->format('Y-m-d');
 


### PR DESCRIPTION
On a new user's first day, `$lastTaskDate` is null and is initialized to "the day before", this initialization had the side effect of modifying the original `$date` object, so any date-related checks that happened after that point were inadvertently using the previous day.

Additionally, changed behavior of default "full day" templates so they don't create any task in case the journey for that date is zero. Please check if you agree with this change of behavior.

Fixes #353.