### PR TITLE
Integrate with external authentication

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -297,3 +297,10 @@ define('NO_FILL_DAYS_TRIGGER_LAST', 27);
  * authentication service is correctly configured before enabling this flag.
  */
 define('USE_EXTERNAL_AUTHENTICATION', false);
+
+/**
+ * HTTP header that will be provided by the external authentication service, in
+ * case it is different from the default PHP_AUTH_USER. To be used in
+ * combination with USE_EXTERNAL_AUTHENTICATION.
+ */
+define('EXTERNAL_AUTHENTICATION_USER_HEADER', '');

--- a/config/config.php
+++ b/config/config.php
@@ -304,3 +304,8 @@ define('USE_EXTERNAL_AUTHENTICATION', false);
  * combination with USE_EXTERNAL_AUTHENTICATION.
  */
 define('EXTERNAL_AUTHENTICATION_USER_HEADER', '');
+
+/**
+ * Additional PostgreSQL connection parameters to be passed to pg_connect.
+ */
+define('EXTRA_DB_CONNECTION_PARAMETERS', '');

--- a/config/config.php
+++ b/config/config.php
@@ -288,3 +288,12 @@ define('NO_FILL_DAYS_TRIGGER_CRITICAL', 21);
  * @global int Value in days to consider sending the last message.
  */
 define('NO_FILL_DAYS_TRIGGER_LAST', 27);
+
+/* New from PhpReport 2.19 */
+
+/**
+ * Enable usage of an external service for authentication.
+ * WARNING: this will bypass internal password check! Make sure your external
+ * authentication service is correctly configured before enabling this flag.
+ */
+define('USE_EXTERNAL_AUTHENTICATION', false);

--- a/config/config.template
+++ b/config/config.template
@@ -297,3 +297,10 @@ define('NO_FILL_DAYS_TRIGGER_LAST', 27);
  * authentication service is correctly configured before enabling this flag.
  */
 define('USE_EXTERNAL_AUTHENTICATION', false);
+
+/**
+ * HTTP header that will be provided by the external authentication service, in
+ * case it is different from the default PHP_AUTH_USER. To be used in
+ * combination with USE_EXTERNAL_AUTHENTICATION.
+ */
+define('EXTERNAL_AUTHENTICATION_USER_HEADER', '');

--- a/config/config.template
+++ b/config/config.template
@@ -304,3 +304,8 @@ define('USE_EXTERNAL_AUTHENTICATION', false);
  * combination with USE_EXTERNAL_AUTHENTICATION.
  */
 define('EXTERNAL_AUTHENTICATION_USER_HEADER', '');
+
+/**
+ * Additional PostgreSQL connection parameters to be passed to pg_connect.
+ */
+define('EXTRA_DB_CONNECTION_PARAMETERS', '');

--- a/config/config.template
+++ b/config/config.template
@@ -288,3 +288,12 @@ define('NO_FILL_DAYS_TRIGGER_CRITICAL', 21);
  * @global int Value in days to consider sending the last message.
  */
 define('NO_FILL_DAYS_TRIGGER_LAST', 27);
+
+/* New from PhpReport 2.19 */
+
+/**
+ * Enable usage of an external service for authentication.
+ * WARNING: this will bypass internal password check! Make sure your external
+ * authentication service is correctly configured before enabling this flag.
+ */
+define('USE_EXTERNAL_AUTHENTICATION', false);

--- a/model/dao/BaseDAO.php
+++ b/model/dao/BaseDAO.php
@@ -67,8 +67,9 @@ abstract class BaseDAO {
         $parameters[] = ConfigurationParametersManager::getParameter('DB_USER');
         $parameters[] = ConfigurationParametersManager::getParameter('DB_NAME');
         $parameters[] = ConfigurationParametersManager::getParameter('DB_PASSWORD');
+        $parameters[] = ConfigurationParametersManager::getParameter('EXTRA_DB_CONNECTION_PARAMETERS');
 
-        $connectionString = "host=$parameters[0] port=$parameters[1] user=$parameters[2] dbname=$parameters[3] password=$parameters[4]";
+        $connectionString = "host=$parameters[0] port=$parameters[1] user=$parameters[2] dbname=$parameters[3] password=$parameters[4] $parameters[5]";
 
         $this->connect = pg_connect($connectionString);
         if ($this->connect == NULL) throw new DBConnectionErrorException($connectionString);

--- a/model/dao/BaseRelationshipDAO.php
+++ b/model/dao/BaseRelationshipDAO.php
@@ -62,21 +62,19 @@ abstract class BaseRelationshipDAO {
      * @todo create the connection pool and remove the connection and its creation from {@link BaseRelationshipDAO}.
      */
     function __construct() {
+        $parameters[] = ConfigurationParametersManager::getParameter('DB_HOST');
+        $parameters[] = ConfigurationParametersManager::getParameter('DB_PORT');
+        $parameters[] = ConfigurationParametersManager::getParameter('DB_USER');
+        $parameters[] = ConfigurationParametersManager::getParameter('DB_NAME');
+        $parameters[] = ConfigurationParametersManager::getParameter('DB_PASSWORD');
+        $parameters[] = ConfigurationParametersManager::getParameter('EXTRA_DB_CONNECTION_PARAMETERS');
 
-    $parameters[] = ConfigurationParametersManager::getParameter('DB_HOST');
-    $parameters[] = ConfigurationParametersManager::getParameter('DB_PORT');
-    $parameters[] = ConfigurationParametersManager::getParameter('DB_USER');
-    $parameters[] = ConfigurationParametersManager::getParameter('DB_NAME');
-    $parameters[] = ConfigurationParametersManager::getParameter('DB_PASSWORD');
+        $connectionString = "host=$parameters[0] port=$parameters[1] user=$parameters[2] dbname=$parameters[3] password=$parameters[4] $parameters[5]";
 
-    $connectionString = "host=$parameters[0] port=$parameters[1] user=$parameters[2] dbname=$parameters[3] password=$parameters[4]";
+        $this->connect = pg_connect($connectionString);
+        if ($this->connect == NULL) throw new DBConnectionErrorException($connectionString);
 
-    $this->connect = pg_connect($connectionString);
-     if ($this->connect == NULL) throw new DBConnectionErrorException($connectionString);
-
-    pg_set_error_verbosity($this->connect, PGSQL_ERRORS_VERBOSE);
-
-
+        pg_set_error_verbosity($this->connect, PGSQL_ERRORS_VERBOSE);
     }
 
     /** Value object constructor from edge A.

--- a/util/LoginManager.php
+++ b/util/LoginManager.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2009 Igalia, S.L. <info@igalia.com>
+ * Copyright (C) 2009-2019 Igalia, S.L. <info@igalia.com>
  *
  * This file is part of PhpReport.
  *
@@ -32,6 +32,7 @@
 require_once(PHPREPORT_ROOT . '/model/facade/UsersFacade.php');
 require_once(PHPREPORT_ROOT . '/model/vo/UserVO.php');
 require_once(PHPREPORT_ROOT . '/model/vo/UserGroupVO.php');
+require_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
 
 /** Login Manager
  *
@@ -63,16 +64,23 @@ class LoginManager {
       return true;
 
     // if we receive the user and password, we try to log in
-    try{
-      $user = UsersFacade::Login($login, $password);
+    try {
+        if (ConfigurationParametersManager::getParameter('USE_EXTERNAL_AUTHENTICATION')) {
+            // bypass password check. We assume that the external authenticator did that.
+            $user = UsersFacade::GetUserByLogin($login);
+            if (!$user) throw new IncorrectLoginException("User not found");
+        }
+        else {
+            $user = UsersFacade::Login($login, $password);
+        }
 
-      unset($_SESSION['user']);
-      $_SESSION['user'] = $user;
+        unset($_SESSION['user']);
+        $_SESSION['user'] = $user;
 
-      return true;
+        return true;
     }
-    catch(IncorrectLoginException $exc){
-      return false;
+    catch (IncorrectLoginException $exc) {
+        return false;
     }
   }
 

--- a/web/login.php
+++ b/web/login.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2009 Igalia, S.L. <info@igalia.com>
+ * Copyright (C) 2009-2019 Igalia, S.L. <info@igalia.com>
  *
  * This file is part of PhpReport.
  *
@@ -34,17 +34,24 @@ function set_location_header_on_login_success_url(){
         header("Location: tasks.php");
 }
 
+/* First check if a custom authentication header was set. */
+$customHeader = ConfigurationParametersManager::getParameter('EXTERNAL_AUTHENTICATION_USER_HEADER');
+if (!empty($customHeader)) {
+    if(isset($_SERVER[$customHeader]) &&
+            LoginManager::login($_SERVER[$customHeader]))
+        set_location_header_on_login_success_url();
+    else
+        echo _("Incorrect login information");
+}
 /* There are Http authentication data: we try to log in*/
-if (isset($_SERVER['PHP_AUTH_USER']))
+else if (isset($_SERVER['PHP_AUTH_USER'])) {
     if(LoginManager::login($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']))
         set_location_header_on_login_success_url();
     else
         echo _("Incorrect login information");
-
-
-
+}
 /* There are POST data: we try to log in */
-if(isset($_POST["login"]) && isset($_POST["password"])) {
+else if(isset($_POST["login"]) && isset($_POST["password"])) {
     if(LoginManager::login($_POST["login"], $_POST["password"]))
         set_location_header_on_login_success_url();
     else


### PR DESCRIPTION
Add two configuration parameters to integrate with external authentication services. They will:
* Bypass password check, relying on the authentication service. PhpReport doesn't need to store passwords in this case. Use with caution!
* Use a different HTTP header to check for the authenticated user name.