### PR TITLE
Fix date displayed in user tasks report

### DIFF
--- a/web/js/userTasksReport.js
+++ b/web/js/userTasksReport.js
@@ -377,18 +377,19 @@ Ext.onReady(function () {
                     return;
                 }
                 var baseParams = {
-                    userId: Ext.getCmp('userLogin').getValue()
+                    userId: Ext.getCmp('userLogin').getValue(),
+                    dateFormat: "m/d/Y",
                 };
 
                 if (Ext.getCmp('startDate').getRawValue() != "") {
                     var date = Ext.getCmp('startDate').getValue();
-                    baseParams.filterStartDate = date.getFullYear() + "-"
-                        + (date.getMonth()+1) + "-" + date.getDate();
+                    baseParams.filterStartDate = (date.getMonth()+1) + "/" +
+                        date.getDate() + "/" + date.getFullYear();
                 }
                 if (Ext.getCmp('endDate').getRawValue() != "") {
                     var date = Ext.getCmp('endDate').getValue();
-                    baseParams.filterEndDate = date.getFullYear() + "-"
-                        + (date.getMonth()+1) + "-" + date.getDate();
+                    baseParams.filterEndDate = (date.getMonth()+1) + "/" +
+                        date.getDate() + "/" + date.getFullYear();
                 }
                 if (Ext.getCmp('filterText').getRawValue() != "") {
                     //this field is the selector for two different, incompatible


### PR DESCRIPTION
Dates were received from the server in Y-m-d format, which assumes the UTC time zone and the time 0:00 ([reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Differences_in_assumed_time_zone)). When translated to local time in areas west of the UTC, they became one day less and, for that reason, dates displayed were wrong.

Worked around the problem by using a different date format without these implications.

Fix #459.