### PR TITLE
Use future contract data to calculate pending holidays

### DIFF
--- a/web/js/viewWorkingHoursResultsReport.js
+++ b/web/js/viewWorkingHoursResultsReport.js
@@ -234,11 +234,12 @@ Ext.onReady(function(){
             }
         }
     });
-    //explicitly set start date so it becomes visible
+    //explicitly set report dates to make them visible
     var defaultStartDate = new Date();
     defaultStartDate.setMonth(0);
     defaultStartDate.setDate(1); //defaultStartDate is 1st Jan of current year
     workingResultsForm.setStartDate(defaultStartDate);
+    workingResultsForm.setEndDate(new Date()); //default end date is today
     workingResultsForm.focus(true);
 
 });


### PR DESCRIPTION
Future contract periods within the same year of the report are now included in the calculations.

Fixes #462.