### PR TITLE
Use correct journey value to calculate pending holidays

### DIFF
--- a/web/services/getPersonalSummaryByDateService.php
+++ b/web/services/getPersonalSummaryByDateService.php
@@ -46,7 +46,7 @@
         $time = round($time,2);
         $time = $time*60;
 
-        if ($time > $limit*$journey*60 ) {
+        if ($journey > 0 && $time > $limit*$journey*60) {
             $work_days = intval($time / ($journey*60));
             $hours = intval(($time - ($work_days*$journey*60))/60);
             $minutes = intval($time - $hours*60 - $work_days*$journey*60);
@@ -129,10 +129,10 @@
         $initDate = new DateTime($date->format('Y').'-01-01');
         $extraHoursSummary = UsersFacade::ExtraHoursReport($initDate, $date, $userVO);
 
-        $currentJourney = 8;
-        $journeys = UsersFacade::GetUserJourneyHistoriesByIntervals($initDate, $date, $userVO->getId());
+        $currentJourney = 0;
+        $journeys = UsersFacade::GetUserJourneyHistoriesByIntervals($date, $date, $userVO->getId());
         if(count($journeys)==1) {
-                $currentJourney = $journeys[0]->getJourney();
+            $currentJourney = $journeys[0]->getJourney();
         }
 
         $extraHours = $extraHoursSummary[1][$userVO->getLogin()]["extra_hours"];


### PR DESCRIPTION
In the case there were multiple contracts (journeys) between the start of the year and the date in course, the code couldn't decide which one to use and it resorted to 8 by default. To fix this, we made the query more specific, setting the current date as both start and end values.

Also, do not use 8 as the fallback journey value so, in case the user doesn't have a contract set in that moment, it reports values in HH:mm format and doesn't attempt to convert it to days.

Fixes #472.