### PR TITLE
New buttons for date filter

### DIFF
--- a/web/js/include/DateIntervalForm.js
+++ b/web/js/include/DateIntervalForm.js
@@ -155,14 +155,14 @@ Ext.ux.DateIntervalForm = Ext.extend(Ext.Panel, {
             //default visual configuration
             frame: true,
             header: false,
-            width: 350,
+            width: 530,
             items:[{
                 id: 'form',
                 layout: 'form',
                 bodyStyle: 'padding:5px 5px 0',
-                labelWidth: 75,
+                labelWidth: 105,
                 defaults: {
-                    width: 230
+                    width: 380
                 },
 
                 //items: start and end date fields

--- a/web/js/include/DateIntervalForm.js
+++ b/web/js/include/DateIntervalForm.js
@@ -205,6 +205,7 @@ Ext.ux.DateIntervalForm = Ext.extend(Ext.Panel, {
             }],
             bbar: {
                 xtype: 'toolbar',
+                enableOverflow: true,
                 items:[{
                     text: 'Last week',
                     xtype: 'button',
@@ -225,6 +226,40 @@ Ext.ux.DateIntervalForm = Ext.extend(Ext.Panel, {
                         var now = new Date();
                         this._getStartDateField().setValue(getPreviousMonday(now));
                         this._getEndDateField().setValue(now);
+
+                        this._fireViewEvent();
+                    }
+                }, '-', {
+                    text: '< Previous week',
+                    xtype: 'button',
+                    scope: this, //scope inside the handler will be the Form object
+                    handler: function () {
+                        var pivot = this._getStartDateField().getValue();
+                        if (!pivot)
+                            pivot = new Date();
+                        pivot.setDate(pivot.getDate() - 7);
+
+                        this._getStartDateField().setValue(
+                            getPreviousMonday(pivot));
+                        this._getEndDateField().setValue(
+                            getNextSunday(pivot));
+
+                        this._fireViewEvent();
+                    }
+                }, {
+                    text: 'Next week >',
+                    xtype: 'button',
+                    scope: this, //scope inside the handler will be the Form object
+                    handler: function () {
+                        var pivot = this._getEndDateField().getValue();
+                        if (!pivot)
+                            pivot = new Date();
+                        pivot.setDate(pivot.getDate() + 7);
+
+                        this._getStartDateField().setValue(
+                            getPreviousMonday(pivot));
+                        this._getEndDateField().setValue(
+                            getNextSunday(pivot));
 
                         this._fireViewEvent();
                     }

--- a/web/js/include/DateIntervalForm.js
+++ b/web/js/include/DateIntervalForm.js
@@ -264,6 +264,21 @@ Ext.ux.DateIntervalForm = Ext.extend(Ext.Panel, {
                         this._fireViewEvent();
                     }
                 }, '-', {
+                    text: 'Last month',
+                    xtype: 'button',
+                    scope: this, //scope inside the handler will be the Form object
+                    handler: function () {
+                        var pivot = new Date();
+                        pivot.setDate(1); // 1st day of current month
+                        pivot.setDate(pivot.getDate() -1); // previous month
+                        this._getEndDateField().setValue(pivot);
+
+                        pivot.setDate(1); // 1st day of previous month
+                        this._getStartDateField().setValue(pivot);
+
+                        this._fireViewEvent();
+                    }
+                }, {
                     text: 'This month',
                     xtype: 'button',
                     scope: this, //scope inside the handler will be the Form object


### PR DESCRIPTION
Adds previous week, next week and last month buttons to the date filter.

It would need some work to fit the buttons on screen, at the moment the buttons that don't fit fall into an "overflow" submenu.

Fixes #477 and #478.