### PR TITLE
Add configuration to link an issue tracker from the menu

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -309,3 +309,20 @@ define('EXTERNAL_AUTHENTICATION_USER_HEADER', '');
  * Additional PostgreSQL connection parameters to be passed to pg_connect.
  */
 define('EXTRA_DB_CONNECTION_PARAMETERS', '');
+
+/* New from PhpReport 2.21 */
+
+/**
+ * Add links to external sites, like issue trackers, from the application menu.
+ * URLs in this list will be added as links to the PhpReport menu bar, at the
+ * top-right. They will appear from right to left. The corresponding entries in
+ * ISSUE_TRACKER_LINKS_TEXT will be used as text for the links.
+ */
+define('ISSUE_TRACKER_LINKS_URL',
+    serialize(array('https://github.com/Igalia/phpreport/issues')));
+
+/**
+ * Add links to external sites from the application menu.
+ * To be used in combination with ISSUE_TRACKER_LINKS_URL, see its entry above.
+ */
+define('ISSUE_TRACKER_LINKS_TEXT', serialize(array('Report an issue')));

--- a/web/include/menubar.php
+++ b/web/include/menubar.php
@@ -21,6 +21,10 @@
 include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
 $SHOW_MENU = LoginManager::isLogged();
 $MENU_COORDINATION = ConfigurationParametersManager::getParameter('MENU_COORDINATION');
+$ISSUE_TRACKER_LINKS_TEXT = unserialize(
+    ConfigurationParametersManager::getParameter('ISSUE_TRACKER_LINKS_TEXT'));
+$ISSUE_TRACKER_LINKS_URL = unserialize(
+    ConfigurationParametersManager::getParameter('ISSUE_TRACKER_LINKS_URL'));
 ?>
 
 <link rel="stylesheet" type="text/css" href="include/menubar.css"/>
@@ -117,4 +121,11 @@ $MENU_COORDINATION = ConfigurationParametersManager::getParameter('MENU_COORDINA
     <li class="right"><a href="logout.php">Logout</a></li>
     <?php } // endif ($SHOW_MENU) ?>
     <li class="right"><a href="../help/user" target="blank">Help</a></li>
+    <?php foreach ($ISSUE_TRACKER_LINKS_TEXT as $key => $text) { ?>
+    <li class="right">
+        <a href="<?php echo $ISSUE_TRACKER_LINKS_URL[$key] ?>" target="blank">
+            <?php echo $text ?>
+        </a>
+    </li>
+    <?php } // end foreach ($ISSUE_TRACKER_LINKS_TEXT) ?>
 </ul>


### PR DESCRIPTION
Added ISSUE_TRACKER_LINKS_URL and ISSUE_TRACKER_LINKS_TEXT to config.php, which allow adding links to the menu with custom text.

Fixes #482.