### PR TITLE
Change `make minify` to use the UglifyJS 3 sytax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ minify:
 	  FILE=`basename -s .js $$i`; \
 	  DIR=`dirname $$i`; \
 	  cd $$DIR; \
-	  uglifyjs $${FILE}.js -o $${FILE}.min.js --source-map $${FILE}.min.js.map -c -m; \
+	  uglifyjs $${FILE}.js --output $${FILE}.min.js \
+	      --source-map "filename=$${FILE}.min.js.map" -c -m; \
 	  cd -; \
 	  done
 	for i in `find web -name *.php`; do \

--- a/docs/developer/devel-setup.rst
+++ b/docs/developer/devel-setup.rst
@@ -13,6 +13,12 @@ Step 0: Dependencies
 Follow the corresponding section from the
 `installation instructions <../admin/installation.rst>`__.
 
+Additionally, a development environment may need the following dependencies to
+generate minified versions of the JS code and the documentation pages:
+
+* Fedora: packages ``uglify-js`` and ``python3-docutils``.
+* Debian/Ubuntu: packages ``uglifyjs`` and ``python3-docutils``.
+
 Step 1: Setting up the database
 ===============================
 


### PR DESCRIPTION
Version 2 of UglifyJS seems to have been removed from most distros, and version 3 CLI is not backwards compatible so we need changes in the Makefile.