### PR TITLE
Add dateBelongsToJourney method to JourneyHistoryVO

### DIFF
--- a/model/vo/JourneyHistoryVO.php
+++ b/model/vo/JourneyHistoryVO.php
@@ -62,4 +62,8 @@ class JourneyHistoryVO extends BaseHistoryVO
 
     /**#@-*/
 
+
+    public function dateBelongsToJourney(DateTime $date): bool{
+        return $date >= $this->getInitDate() && $date <= $this->getEndDate();
+    }
 }

--- a/tests/model/vo/JourneyHistoryVOTest.php
+++ b/tests/model/vo/JourneyHistoryVOTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+if (!defined('PHPREPORT_ROOT')) define('PHPREPORT_ROOT', __DIR__ . '/../../../');
+
+include_once(PHPREPORT_ROOT . '/model/vo/JourneyHistoryVO.php');
+
+class JourneyHistoryVOTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->instance = new \JourneyHistoryVO();
+        $this->instance->setJourney(5);
+        $this->instance->setUserId(1);
+        $this->instance->setInitDate(date_create("2021-01-01"));
+        $this->instance->setEndDate(date_create("2021-06-01"));
+    }
+
+    public function testReturnFalseIfDateIsBeforeJourney(): void
+    {
+        $date = date_create("2020-01-01");
+        $this->assertEquals(
+            false,
+            $this->instance->dateBelongsToJourney($date)
+        );
+    }
+
+    public function testReturnTrueIfDateBelongsToJourney(): void
+    {
+        $date = date_create("2021-05-01");
+        $this->assertEquals(
+            true,
+            $this->instance->dateBelongsToJourney($date)
+        );
+    }
+
+    public function testReturnTrueIfDateEqualsInitOfJourney(): void
+    {
+        $date = date_create("2021-01-01");
+        $this->assertEquals(
+            true,
+            $this->instance->dateBelongsToJourney($date)
+        );
+    }
+
+    public function testReturnTrueIfDateEqualsEndOfJourney(): void
+    {
+        $date = date_create("2021-06-01");
+        $this->assertEquals(
+            true,
+            $this->instance->dateBelongsToJourney($date)
+        );
+    }
+
+    public function testReturnFalseIfDateIsAfterJourney(): void
+    {
+        $date = date_create("2021-07-01");
+        $this->assertEquals(
+            false,
+            $this->instance->dateBelongsToJourney($date)
+        );
+    }
+}


### PR DESCRIPTION
This method checks if a given date is between the init and end dates of a journey.

It will be used to find what journey a user had in the date of a specific task.

@jaragunde I thought of adding this "utility" methods next to their VO classes, let me know if you think they should be somewhere else.