### PR TITLE
Fix regression in accumulated hours report with LDAP enabled.

### DIFF
--- a/model/dao/BelongsDAO/LDAPBelongsDAO.php
+++ b/model/dao/BelongsDAO/LDAPBelongsDAO.php
@@ -75,11 +75,13 @@ class LDAPBelongsDAO extends BelongsDAO{
      */
     protected function setAValues($row)
     {
+
         $userVO = new UserVO();
 
+        $userVO->setId($row['id']);
         $userVO->setLogin($row['login']);
+        $userVO->setPassword($row['password']);
         $userVO->setGroups((array) $this->getByUserLogin($userVO->getLogin()));
-        // User data retrieved from LDAP does not contain ID or password
 
         return $userVO;
     }
@@ -194,7 +196,9 @@ class LDAPBelongsDAO extends BelongsDAO{
 
         for ($i=0;$i<$info[0]["uniquemember"]["count"];$i++) {
             strtok($info[0]["uniquemember"][$i],"=,");
-            $user["login"]=strtok("=,");
+            $user["login"] = strtok("=,");
+            $user["id"] = null;
+            $user["password"] = null;
             $usersLDAP[]=$this->setAValues($user);
         }
 


### PR DESCRIPTION
This is a regression caused by commit 981533e62f1e83dbd68cd80dc215385c37d86c90.

The function `LDAPBelongsDAO->setAValues` may be called from `BaseRelationshipDAO->executeFromB`, so it's not true that it never receives the id and password fields.

Restored the original code in `LDAPBelongsDAO->setAValues`, and fixed the PHP warning that we wanted to address in a different way.