### PR TITLE
Implement holiday editing methods

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -45,6 +45,7 @@ $permissions = array(
         '/services/getTasksFiltered.php', '/userTasksReport.php',
         //holidays management
         '/services/getHolidays.php',
+        '/services/updateHolidays.php',
         '/holidayManagement.php',
         //templates
         '/services/createTemplatesService.php', '/services/getUserTemplatesService.php',

--- a/model/facade/ProjectsFacade.php
+++ b/model/facade/ProjectsFacade.php
@@ -34,6 +34,7 @@ include_once(PHPREPORT_ROOT . '/model/facade/action/GetAllProjectsAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetUserProjectsAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetProjectUsersAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetProjectAction.php');
+include_once(PHPREPORT_ROOT . '/model/facade/action/GetProjectByDescriptionAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetCustomProjectAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/AssignUserToProjectAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/DeassignUserFromProjectAction.php');

--- a/tests/web/services/HolidayServiceTest.php
+++ b/tests/web/services/HolidayServiceTest.php
@@ -100,4 +100,31 @@ class HolidayServiceTest extends TestCase
             $this->instance->datesToRanges($dates)
         );
     }
+
+    public function testReturnTrueIfDateIsSaturday(): void
+    {
+        $date = '2021-09-25';
+        $this->assertEquals(
+            true,
+            $this->instance->isWeekend($date)
+        );
+    }
+
+    public function testReturnTrueIfDateIsSunday(): void
+    {
+        $date = '2021-09-26';
+        $this->assertEquals(
+            true,
+            $this->instance->isWeekend($date)
+        );
+    }
+
+    public function testReturnFalseIfDateIsNotOnWeekend(): void
+    {
+        $date = '2021-09-24';
+        $this->assertEquals(
+            false,
+            $this->instance->isWeekend($date)
+        );
+    }
 }

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -46,6 +46,7 @@ include_once("include/header.php");
                 </li>
             </ul>
             <p class="warning info"><strong>TIP:</strong> Double click on single dates if you want to delete existing holidays</p>
+            <button v-on:click="onSaveClick">Save Holidays</button>
         </div>
     </div>
     <div class="calendar">

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -61,6 +61,8 @@ include_once("include/header.php");
             show-iso-weeknumbers
             :select-attribute="selectAttribute"
             @dayclick="onDayClick"
+            :min-date="initDate"
+            :max-date="endDate"
         />
     </div>
 </div>

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -45,6 +45,7 @@ include_once("include/header.php");
                     {{ date }}
                 </li>
             </ul>
+            <p class="warning info"><strong>TIP:</strong> Double click on single dates if you want to delete existing holidays</p>
         </div>
     </div>
     <div class="calendar">

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -42,7 +42,9 @@ include_once("include/header.php");
             <p>Total booked: {{ totalHolidays }}</p>
 
             <p class="warning info"><strong>TIP:</strong> Double click on single dates if you want to delete existing holidays</p>
-            <button v-on:click="onSaveClick">Save Holidays</button>
+            <p class="text-right">
+                <button class="btn" v-on:click="onSaveClick">Save Holidays</button>
+            </p>
         </div>
     </div>
     <div class="calendar">

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -40,11 +40,7 @@ include_once("include/header.php");
         <div class="holidaysList">
             <h2 class="sidebarTitle"><?php echo date("Y"); ?> Holidays</h2>
             <p>Total booked: {{ totalHolidays }}</p>
-            <ul>
-                <li v-for="date in dates" :key="date">
-                    {{ date }}
-                </li>
-            </ul>
+
             <p class="warning info"><strong>TIP:</strong> Double click on single dates if you want to delete existing holidays</p>
             <button v-on:click="onSaveClick">Save Holidays</button>
         </div>

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -41,14 +41,14 @@ include_once("include/header.php");
             <h2 class="sidebarTitle"><?php echo date("Y"); ?> Holidays</h2>
             <p>Total booked: {{ totalHolidays }}</p>
             <ul>
-                <li v-for="date in dates" :key="date.start">
-                    {{ date.start }}<span v-if="date.start !== date.end"> to {{ date.end }}</span>
+                <li v-for="date in dates" :key="date">
+                    {{ date }}
                 </li>
             </ul>
         </div>
     </div>
     <div class="calendar">
-        <v-calendar
+        <v-date-picker
             :from-page="{ month: 1, year: 2021 }"
             is-range
             v-model="range"
@@ -58,6 +58,7 @@ include_once("include/header.php");
             :columns="$screens({ default: 2, lg: 4 })"
             show-iso-weeknumbers
             :select-attribute="selectAttribute"
+            @dayclick="onDayClick"
         />
     </div>
 </div>

--- a/web/include/phpreport.css
+++ b/web/include/phpreport.css
@@ -79,3 +79,22 @@ div#tasks textarea {
     background-color: #edf5ff;
     border-color: #7da6db;
 }
+
+.text-right {
+    text-align: right;
+}
+
+.btn {
+    padding: 10px 15px;
+    background-color: #fff;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    cursor: pointer;
+    box-shadow: 2px 2px 2px #eee;
+    text-transform: uppercase;
+    font-weight: bold;
+}
+
+.btn:hover {
+    color: #0f60ca;
+}

--- a/web/include/phpreport.css
+++ b/web/include/phpreport.css
@@ -66,3 +66,16 @@ div#tasks textarea {
     padding: 2px 5px;
     margin-left: 5px;
 }
+
+.warning {
+    font-size: 0.8em;
+    border: 1px solid #eee;
+    border-radius: 5px;
+    padding: 10px;
+    margin: 10px 0;
+}
+
+.warning.info {
+    background-color: #edf5ff;
+    border-color: #7da6db;
+}

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -17,6 +17,37 @@
  * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+function formatDate(date) {
+    // Receives a date object and returns a string in the format YYYY-MM-DD.
+    // The subtract below is to discard timezone.
+    return new Date(date.getTime() - (date.getTimezoneOffset() * 60000))
+        .toISOString()
+        .split("T")[0];
+}
+
+function deleteRangeAndDays(ranges, day, days) {
+    rangeIdx = ranges.findIndex(range => range.coveredDates.includes(day));
+    let daysToDelete = [];
+    // Remove the overlaping range
+    if (rangeIdx > -1) {
+        daysToDelete = ranges[rangeIdx].coveredDates;
+        ranges.splice(rangeIdx, 1);
+        // Remove all days covered in that range
+        days = days.filter(d => !daysToDelete.includes(d));
+    };
+    return { ranges, days };
+}
+
+function indexOfRange(attrs, date) {
+    return attrs.findIndex(attr => attr.dates.findIndex(dt => formatDate(dt.end) == formatDate(date)) >= 0);
+}
+
+function addDays(date, days) {
+    var result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+}
+
 var app = new Vue({
     el: '#holidaysApp',
     data() {
@@ -25,6 +56,8 @@ var app = new Vue({
             range: {},
             ranges: [],
             total: null,
+            latestDelete: null,
+            isEndOfRange: false,
 
             // Clean selected range styles to avoid confusion when
             // removing dates
@@ -45,7 +78,6 @@ var app = new Vue({
                             backgroundColor: 'transparent',
                         }
                     },
-
                 },
             },
         };
@@ -73,10 +105,11 @@ var app = new Vue({
                     end: { fillMode: 'outline' },
                 },
                 dates: { start: new Date(dt.start + 'T00:00:00'), end: new Date(dt.end + 'T00:00:00') },
+                coveredDates: datesAndRanges.dates.filter(d => d >= dt.start && d <= dt.end)
             }));
 
             this.ranges = attributes;
-            this.days = datesAndRanges.ranges;
+            this.days = datesAndRanges.dates;
             this.total = datesAndRanges.dates.length;
         };
 
@@ -92,5 +125,66 @@ var app = new Vue({
         totalHolidays() {
             return this.total;
         }
-    }
+    },
+    methods: {
+        onDayClick(day) {
+            let endDay = day.date;
+
+            // Check if the selected day is already in the list, if it is, it means the user
+            // is edditing or removing some range, so delete respective range and dates
+            if (this.days.findIndex(d => d === day.id) >= 0) {
+                const { ranges, days } = deleteRangeAndDays(this.ranges, day.id, this.days);
+                this.ranges = ranges;
+                this.days = days;
+
+                // We need to keep track of the latest deleted day in case the user is removing
+                // a single date range
+                this.latestDelete = day.id;
+            }
+
+            // The data structure of v-calendar is a bit confusing and inconsistent, so we need to
+            // find out wich of the ranges corresponds to the current one to make sure we grab the
+            // correct start date
+            const idx = indexOfRange(day.attributes, day.date);
+
+            if (this.isEndOfRange) {
+                const startDay = day.attributes[idx].dates[0].start;
+                const diff = Math.floor((day.date - startDay) / 86400000);
+                const rangeDays = [];
+
+                // If the latest deleted day is the same that was clicked, it means
+                // it was just deleted so we don't want to add it again
+                if ((diff != 0) || (this.latestDelete != day.id)) {
+                    for (let i = 0; i <= diff; i++) {
+                        const currentDay = formatDate(addDays(startDay, i));
+
+                        // Remove any overlaping range in the middle
+                        if (this.days.findIndex(d => d === currentDay) >= 0) {
+                            const { ranges, days } = deleteRangeAndDays(this.ranges, currentDay, this.days);
+                            this.ranges = ranges;
+                            this.days = days;
+                        }
+
+                        rangeDays.push(currentDay);
+                        this.days.push(currentDay);
+                    }
+                    this.ranges.push({
+                        highlight: {
+                            start: { fillMode: 'outline' },
+                            base: { fillMode: 'light' },
+                            end: { fillMode: 'outline' },
+                        },
+                        dates: { start: startDay, end: endDay },
+                        coveredDates: rangeDays
+                    });
+                }
+                this.latestDelete = null;
+                this.range = null;
+                this.value = null;
+            }
+
+            // Next click will be the opposite of the current state
+            this.isEndOfRange = !this.isEndOfRange;
+        }
+    },
 })

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -185,6 +185,23 @@ var app = new Vue({
 
             // Next click will be the opposite of the current state
             this.isEndOfRange = !this.isEndOfRange;
+        },
+        onSaveClick: async function () {
+            const currentYear = new Date().getFullYear();
+            const url = ` services/updateHolidays.php?init=${currentYear}-01-01&end=${currentYear}-12-31`;
+
+            const res = await fetch(url, {
+                method: 'POST',
+                mode: 'same-origin',
+                cache: 'no-cache',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                referrerPolicy: 'no-referrer',
+                body: JSON.stringify(this.days)
+            });
+            const datesAndRanges = await res.json();
         }
     },
 })

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -58,6 +58,8 @@ var app = new Vue({
             total: null,
             latestDelete: null,
             isEndOfRange: false,
+            init: new Date(new Date().getFullYear(), 0, 1),
+            end: new Date(new Date().getFullYear(), 11, 31),
 
             // Clean selected range styles to avoid confusion when
             // removing dates
@@ -84,8 +86,7 @@ var app = new Vue({
     },
     created() {
         const fetchData = async () => {
-            const currentYear = new Date().getFullYear();
-            const url = `services/getHolidays.php?init=${currentYear}-01-01&end=${currentYear}-12-31`;
+            const url = `services/getHolidays.php?init=${formatDate(this.init)}&end=${formatDate(this.end)}`;
             const res = await fetch(url, {
                 method: 'GET',
                 mode: 'same-origin',
@@ -124,6 +125,12 @@ var app = new Vue({
         },
         totalHolidays() {
             return this.total;
+        },
+        initDate() {
+            return this.init;
+        },
+        endDate() {
+            return this.end;
         }
     },
     methods: {
@@ -187,8 +194,7 @@ var app = new Vue({
             this.isEndOfRange = !this.isEndOfRange;
         },
         onSaveClick: async function () {
-            const currentYear = new Date().getFullYear();
-            const url = ` services/updateHolidays.php?init=${currentYear}-01-01&end=${currentYear}-12-31`;
+            const url = `services/updateHolidays.php?init=${formatDate(this.init)}&end=${formatDate(this.end)}`;
 
             const res = await fetch(url, {
                 method: 'POST',

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -98,20 +98,7 @@ var app = new Vue({
                 referrerPolicy: 'no-referrer',
             });
             const datesAndRanges = await res.json();
-
-            const attributes = datesAndRanges.ranges.map(dt => ({
-                highlight: {
-                    start: { fillMode: 'outline' },
-                    base: { fillMode: 'light' },
-                    end: { fillMode: 'outline' },
-                },
-                dates: { start: new Date(dt.start + 'T00:00:00'), end: new Date(dt.end + 'T00:00:00') },
-                coveredDates: datesAndRanges.dates.filter(d => d >= dt.start && d <= dt.end)
-            }));
-
-            this.ranges = attributes;
-            this.days = datesAndRanges.dates;
-            this.total = datesAndRanges.dates.length;
+            this.updateDates(datesAndRanges);
         };
 
         fetchData();
@@ -134,6 +121,20 @@ var app = new Vue({
         }
     },
     methods: {
+        updateDates(datesAndRanges) {
+            const attributes = datesAndRanges.ranges.map(dt => ({
+                highlight: {
+                    start: { fillMode: 'outline' },
+                    base: { fillMode: 'light' },
+                    end: { fillMode: 'outline' },
+                },
+                dates: { start: new Date(dt.start + 'T00:00:00'), end: new Date(dt.end + 'T00:00:00') },
+                coveredDates: datesAndRanges.dates.filter(d => d >= dt.start && d <= dt.end)
+            }));
+            this.ranges = attributes;
+            this.days = datesAndRanges.dates;
+            this.total = datesAndRanges.dates.length;
+        },
         onDayClick(day) {
             let endDay = day.date;
 

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -209,6 +209,7 @@ var app = new Vue({
                 body: JSON.stringify(this.days)
             });
             const datesAndRanges = await res.json();
+            this.updateDates(datesAndRanges);
         }
     },
 })

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -38,6 +38,11 @@ class HolidayService
         $this->loginManager = $loginManager;
     }
 
+    function isWeekend(string $date): bool
+    {
+        return (date('N', strtotime($date)) >= 6);
+    }
+
     /** Group dates into date ranges
      *
      * It receives an array of dates in the ISO format YYYY-MM-DD

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -132,4 +132,17 @@ class HolidayService
 
         return ['dates' => $vacations, 'ranges' => $this->datesToRanges($vacations)];
     }
+
+    public function updateUserVacations(array $vacations, string $init = NULL, string $end = NULL): array
+    {
+        if (!$this->loginManager::isLogged()) {
+            return ['error' => 'User not logged in'];
+        }
+
+        if (!$this->loginManager::isAllowed()) {
+            return ['error' => 'Forbidden service for this User'];
+        }
+
+        return [];
+    }
 }

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -108,22 +108,8 @@ class HolidayService
             return ['error' => 'Forbidden service for this User'];
         }
 
-        $dateFormat = "Y-m-d";
-
-        if ($init != "") {
-            $initParse = date_parse_from_format($dateFormat, $init);
-            $init = "{$initParse['year']}-{$initParse['month']}-{$initParse['day']}";
-        } else
-            $init = "1900-01-01";
-
-        $init = date_create($init);
-
-        if ($end != "") {
-            $endParse = date_parse_from_format($dateFormat, $end);
-            $end = "{$endParse['year']}-{$endParse['month']}-{$endParse['day']}";
-            $end = date_create($end);
-        } else
-            $end = date_create(date('Y') . "-12-31");
+        $init = date_create($init ?? "1900-01-01");
+        $end = date_create($end ?? date('Y') . "-12-31");
 
         $userVO = new \UserVO();
         $userVO->setLogin($_SESSION['user']->getLogin());

--- a/web/services/updateHolidays.php
+++ b/web/services/updateHolidays.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phpreport\Web\services\HolidayService;
+
+define('PHPREPORT_ROOT', __DIR__ . '/../../');
+
+require_once(PHPREPORT_ROOT . "/vendor/autoload.php");
+require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
+
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    return;
+}
+
+$vacationsPayload = json_decode(file_get_contents('php://input'), true);
+
+$init = $_GET['init'] ?? NULL;
+$end = $_GET['end'] ?? NULL;
+
+$loginManager = new \LoginManager();
+
+$holidayService = new HolidayService($loginManager);
+
+$holidays = $holidayService->updateUserVacations($vacationsPayload, $init, $end);
+
+if (array_key_exists('error', $holidays)) {
+    // user is logged out or doesn't have permission
+    http_response_code(403);
+}
+
+echo json_encode($holidays);


### PR DESCRIPTION
Use the same view that displays the holidays yearly to allow the user to add and edit existing holidays.
Given an array of days:
1 - delete the vacation days that are not in the list but were booked previously by the user.
2 - create new holiday tasks from the array that weren't booked yet.

Note: Holidays selected in weekends are ignored, holidays that don't belong to any journey are also ignored (for instance, trying to book a holiday in a date previous to when the person joined the company).

Next steps of the implementation:
- distinguish half leave from full day holidays visually
- display more information in the sidebar
- display success/failure messages after saving

Part of #510

Example:
- saving valid holidays and then trying to save holidays in a period before the user joined the company fails

https://user-images.githubusercontent.com/333447/134967700-0149d455-dfaf-4476-bbc0-46974282921b.mov
