### PR TITLE
Fix weekly goal calc if in last week of the year

### DIFF
--- a/model/facade/action/GetPersonalSummaryByLoginDateAction.php
+++ b/model/facade/action/GetPersonalSummaryByLoginDateAction.php
@@ -195,15 +195,15 @@ class GetPersonalSummaryByLoginDateAction extends Action{
         }
         $totalResults = $dao->getPersonalSummary($user->getId(), $this->date);
 
+        $totalResults['weekly_goal'] = 0;
         if( $this->currentJourney ) {
             $extraGoalHoursSet = 0;
             $weeksTillEndOfJourneyPeriod = $this->getWeeksTillEndOfJourneyPeriod();
-            $extraGoalHoursSet += $this->currentUserGoal->getExtraHours() / $weeksTillEndOfJourneyPeriod;
-
-            $originalHoursToBeWorked = ($this->getWorkableHoursInThisPeriod() - $this->getWorkedHoursInThisPeriod())/ $weeksTillEndOfJourneyPeriod;
-            $totalResults['weekly_goal'] = round( ( $originalHoursToBeWorked + $extraGoalHoursSet ) * 60);
-        } else {
-            $totalResults['weekly_goal'] = 0;
+            if ($weeksTillEndOfJourneyPeriod > 0) {
+                $extraGoalHoursSet += $this->currentUserGoal->getExtraHours() / $weeksTillEndOfJourneyPeriod;
+                $originalHoursToBeWorked = ($this->getWorkableHoursInThisPeriod() - $this->getWorkedHoursInThisPeriod())/ $weeksTillEndOfJourneyPeriod;
+                $totalResults['weekly_goal'] = round( ( $originalHoursToBeWorked + $extraGoalHoursSet ) * 60);
+            }
         }
         return $totalResults;
 


### PR DESCRIPTION
If the week in case is the last week of the year, this method would fail because weeksTillEndOfJourneyPeriod is 0, causing a division by 0 exception.