### PR TITLE
Display today in the calendar

### DIFF
--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -131,6 +131,12 @@ var app = new Vue({
                 dates: { start: new Date(dt.start + 'T00:00:00'), end: new Date(dt.end + 'T00:00:00') },
                 coveredDates: datesAndRanges.dates.filter(d => d >= dt.start && d <= dt.end)
             }));
+            // Add today
+            attributes.push({
+                bar: 'orange',
+                dates: { start: new Date(), end: new Date() },
+            });
+
             this.ranges = attributes;
             this.days = datesAndRanges.dates;
             this.total = datesAndRanges.dates.length;


### PR DESCRIPTION
Minor improvement to help the user to visualize enjoyed and scheduled holidays better (enjoyed being everything before today and scheduled everything after today).

<img width="366" alt="Screen Shot 2021-10-13 at 19 21 28" src="https://user-images.githubusercontent.com/333447/137220652-75b5411a-4430-42dc-8af1-31b7b81e8851.png">


