### PR TITLE
Allow paramenter to be null 

### DIFF
--- a/model/facade/action/GetHolidayHoursBaseAction.php
+++ b/model/facade/action/GetHolidayHoursBaseAction.php
@@ -25,11 +25,11 @@ include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
 
 abstract class GetHolidayHoursBaseAction extends Action
 {
-    private UserVO $user;
+    private ?UserVO $user;
     private DateTime $init;
     private DateTime $end;
 
-    public function __construct(DateTime $init, DateTime $end, UserVO $user = NULL)
+    public function __construct(DateTime $init, DateTime $end, ?UserVO $user = NULL)
     {
         $this->init = $init;
         $this->end = $end;


### PR DESCRIPTION
The report web/viewWorkingHoursResultsReport.php was broken
because it didn't need to send a UserVO as parameter, so we need
to allow it to be nullable.