### PR TITLE
Increase the number of months available in the calendar

### DIFF
--- a/model/facade/UsersFacade.php
+++ b/model/facade/UsersFacade.php
@@ -259,8 +259,8 @@ abstract class UsersFacade {
         return $action->execute();
     }
 
-    static function GetHolidayHoursSummary(DateTime $init, DateTime $end, UserVO $user = NULL) {
-        $action = new GetHolidayHoursSummaryAction($init, $end, $user);
+    static function GetHolidayHoursSummary(DateTime $init, DateTime $end, UserVO $user = NULL, Datetime $referenceDate = NULL) {
+        $action = new GetHolidayHoursSummaryAction($init, $end, $user, $referenceDate);
         return $action->execute();
     }
 

--- a/model/facade/action/GetHolidayHoursBaseAction.php
+++ b/model/facade/action/GetHolidayHoursBaseAction.php
@@ -36,7 +36,7 @@ abstract class GetHolidayHoursBaseAction extends Action
         $this->user = $user;
     }
 
-    protected function getHoursSummary(DateTime $today = NULL): array
+    protected function getHoursSummary(DateTime $referenceDate = NULL): array
     {
         $taskDao = DAOFactory::getTaskDAO();
         $journeyHistoryDao = DAOFactory::getJourneyHistoryDAO();
@@ -130,8 +130,8 @@ abstract class GetHolidayHoursBaseAction extends Action
                 $holidayHours = ($workHours / (365 * 8)) * ConfigurationParametersManager::getParameter('YEARLY_HOLIDAY_HOURS');
                 $userAvailableHours[$userVO->getLogin()] = $holidayHours;
 
-                $today = $today ?? new DateTime();
-                $userEnjoyedHours[$userVO->getLogin()] = $taskDao->getVacations($userVO, $reportInit, $today)["add_hours"] ?? 0;
+                $referenceDate = $referenceDate ?? new DateTime();
+                $userEnjoyedHours[$userVO->getLogin()] = $taskDao->getVacations($userVO, $reportInit, $referenceDate)["add_hours"] ?? 0;
                 $userScheduledHours[$userVO->getLogin()] = $vacations - $userEnjoyedHours[$userVO->getLogin()];
 
                 // The difference is the number of pending holiday hours

--- a/model/facade/action/GetHolidayHoursSummaryAction.php
+++ b/model/facade/action/GetHolidayHoursSummaryAction.php
@@ -22,16 +22,16 @@ include_once(PHPREPORT_ROOT . '/model/facade/action/GetHolidayHoursBaseAction.ph
 
 class GetHolidayHoursSummaryAction extends GetHolidayHoursBaseAction
 {
-    public function __construct(DateTime $init, DateTime $end, UserVO $user = NULL, Datetime $today = NULL)
+    public function __construct(DateTime $init, DateTime $end, UserVO $user = NULL, Datetime $referenceDate = NULL)
     {
         parent::__construct($init, $end, $user);
         $this->preActionParameter = "GET_HOLIDAY_HOURS_SUMMARY_PREACTION";
         $this->postActionParameter = "GET_HOLIDAY_HOURS_SUMMARY_POSTACTION";
-        $this->today = $today ?? new DateTime();
+        $this->referenceDate = $referenceDate ?? new DateTime();
     }
 
     protected function doExecute()
     {
-        return $this->getHoursSummary();
+        return $this->getHoursSummary($referenceDate = $this->referenceDate);
     }
 }

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -43,7 +43,7 @@ include_once("include/header.php");
     <div class="holidayContainer">
         <div class="sidebar">
             <div class="holidaysList">
-                <h2 class="sidebarTitle"><?php echo date("Y"); ?> Holidays</h2>
+                <h2 class="sidebarTitle">Holidays Summary for <?php echo date("Y"); ?></h2>
                 <div v-if="!isEditing" class="autocompleteContainer">
                     <input
                         class="autocompleteSearchInput"

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -105,7 +105,7 @@ include_once("include/header.php");
                 <v-date-picker ref="calendar" :from-page="fromPage" is-range v-model="range" :attributes="ranges" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :select-attribute="selectAttribute" @dayclick="onDayClick" @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
             <div v-show="!isEditing">
-                <v-calendar is-range :from-page="{month: 1, year: currentYear}" v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
+                <v-calendar is-range :from-page="fromPage" v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
         </div>
         <div class="snackbarWrapper">

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -43,7 +43,7 @@ include_once("include/header.php");
     <div class="holidayContainer">
         <div class="sidebar">
             <div class="holidaysList">
-                <h2 class="sidebarTitle">Holidays Summary for <?php echo date("Y"); ?></h2>
+                <h2 class="sidebarTitle">Holidays Summary for {{ currentYear }}</h2>
                 <div v-if="!isEditing" class="autocompleteContainer">
                     <input
                         class="autocompleteSearchInput"
@@ -102,10 +102,10 @@ include_once("include/header.php");
         </div>
         <div class="calendar">
             <div v-if="isEditing">
-                <v-date-picker is-range v-model="range" :attributes="ranges" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :select-attribute="selectAttribute" @dayclick="onDayClick" :min-date="init" :max-date="end" />
+                <v-date-picker ref="calendar" :from-page="fromPage" is-range v-model="range" :attributes="ranges" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :select-attribute="selectAttribute" @dayclick="onDayClick" @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
             <div v-show="!isEditing">
-                <v-calendar is-range v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :min-date="init" :max-date="end" />
+                <v-calendar is-range :from-page="{month: 1, year: currentYear}" v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
         </div>
         <div class="snackbarWrapper">

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -71,17 +71,19 @@ var app = new Vue({
             range: {},
             teamRange: {},
             teamAttributes: {},
-            teamDaysByWeek: {},
+            teamDaysByWeek: [],
             teamDays: [],
             ranges: [],
             isEditing: true,
             userSummary: {},
             personalSummary: {},
-            daysByWeek: null,
+            daysByWeek: [],
             latestDelete: null,
             isEndOfRange: false,
-            init: new Date(new Date().getFullYear() - 1, 6, 1),
-            end: new Date(new Date().getFullYear() + 1, 2, 31),
+            init: new Date(new Date().getFullYear() - 1, 0, 1),
+            end: new Date(new Date().getFullYear() + 1, 11, 31),
+            fromPage: { month: 1, year: new Date().getFullYear() },
+            currentYear: new Date().getFullYear(),
             serverMessages: [],
             // Clean selected range styles to avoid confusion when
             // removing dates
@@ -122,7 +124,8 @@ var app = new Vue({
             return this.ranges;
         },
         weeksList() {
-            return this.isEditing ? this.daysByWeek : this.teamDaysByWeek;
+            const weeks = this.isEditing ? this.daysByWeek : this.teamDaysByWeek;
+            return weeks?.filter(week => week.weekNumber.startsWith(this.currentYear));
         },
         summary() {
             return this.isEditing ? this.personalSummary : this.userSummary;
@@ -157,7 +160,13 @@ var app = new Vue({
             }
         },
         async fetchSummary(user = null) {
-            let url = `services/getPersonalSummaryByDateService.php?date=${formatDate(new Date(new Date().getFullYear(), 11, 31))}`;
+            let referenceDate = new Date();
+            if (this.currentYear < referenceDate.getFullYear()) {
+                referenceDate = new Date(this.currentYear, 11, 31);
+            } else if (this.currentYear > referenceDate.getFullYear()) {
+                referenceDate = new Date(this.currentYear, 0, 1);
+            }
+            let url = `services/getPersonalSummaryByDateService.php?date=${formatDate(referenceDate)}`;
             if (user) {
                 url += `&userLogin=${user}`
             }
@@ -256,6 +265,13 @@ var app = new Vue({
         onDayClick(day) {
             let endDay = day.date;
 
+            // Make sure the montha that are being displayed are not changed
+            // after clicking on a day
+            this.fromPage = {
+                month: this.$refs.calendar.$refs.calendar.pages[0].month,
+                year: this.$refs.calendar.$refs.calendar.pages[0].year
+            };
+
             // Check if the selected day is already in the list, if it is, it means the user
             // is edditing or removing some range, so delete respective range and dates
             if (this.days.findIndex(d => d === day.id) >= 0) {
@@ -311,6 +327,14 @@ var app = new Vue({
 
             // Next click will be the opposite of the current state
             this.isEndOfRange = !this.isEndOfRange;
+        },
+        updateCurrentYear(fromPage) {
+            this.currentYear = fromPage.year;
+            if (this.isEditing) {
+                this.fetchSummary();
+            } else {
+                this.fetchSummary(this.searchUser);
+            }
         },
         onSaveClick: async function () {
             const url = `services/updateHolidays.php?init=${formatDate(this.init)}&end=${formatDate(this.end)}`;

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -82,7 +82,8 @@ var app = new Vue({
             isEndOfRange: false,
             init: new Date(new Date().getFullYear() - 1, 0, 1),
             end: new Date(new Date().getFullYear() + 1, 11, 31),
-            fromPage: { month: 1, year: new Date().getFullYear() },
+            personalFromPage: { month: 1, year: new Date().getFullYear() },
+            teamFromPage: { month: 1, year: new Date().getFullYear() },
             currentYear: new Date().getFullYear(),
             serverMessages: [],
             // Clean selected range styles to avoid confusion when
@@ -129,6 +130,9 @@ var app = new Vue({
         },
         summary() {
             return this.isEditing ? this.personalSummary : this.userSummary;
+        },
+        fromPage() {
+            return this.isEditing ? this.personalFromPage : this.teamFromPage;
         }
     },
     methods: {
@@ -267,7 +271,7 @@ var app = new Vue({
 
             // Make sure the montha that are being displayed are not changed
             // after clicking on a day
-            this.fromPage = {
+            this.personalFromPage = {
                 month: this.$refs.calendar.$refs.calendar.pages[0].month,
                 year: this.$refs.calendar.$refs.calendar.pages[0].year
             };

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -80,8 +80,8 @@ var app = new Vue({
             daysByWeek: null,
             latestDelete: null,
             isEndOfRange: false,
-            init: new Date(new Date().getFullYear(), 0, 1),
-            end: new Date(new Date().getFullYear(), 11, 31),
+            init: new Date(new Date().getFullYear() - 1, 6, 1),
+            end: new Date(new Date().getFullYear() + 1, 2, 31),
             serverMessages: [],
             // Clean selected range styles to avoid confusion when
             // removing dates
@@ -157,7 +157,7 @@ var app = new Vue({
             }
         },
         async fetchSummary(user = null) {
-            let url = `services/getPersonalSummaryByDateService.php?date=${formatDate(this.end)}`;
+            let url = `services/getPersonalSummaryByDateService.php?date=${formatDate(new Date(new Date().getFullYear(), 11, 31))}`;
             if (user) {
                 url += `&userLogin=${user}`
             }

--- a/web/services/getPersonalSummaryByDateService.php
+++ b/web/services/getPersonalSummaryByDateService.php
@@ -95,7 +95,7 @@ do {
 
     // Report holidays from the entire year, including those later than $date
     $endYearDate = new DateTime($date->format('Y') . '-12-31');
-    $holidays = UsersFacade::GetHolidayHoursSummary($initYearDate, $endYearDate, $userVO);
+    $holidays = UsersFacade::GetHolidayHoursSummary($initYearDate, $endYearDate, $userVO, $date);
     $pendingHolidays = $holidays["pendingHours"][$userVO->getLogin()];
     $pendingHolidays = HolidayService::formatHours($pendingHolidays, $currentJourney, 5);
 


### PR DESCRIPTION
Especially by the end and beginning of the year, is useful to be
able to see close months from the past or next year so display
the holidays since July from past year until March of the
next year.

Needs https://github.com/Igalia/phpreport/pull/531 to be merged first.