### PR TITLE
Sync PhpReport holidays with CalDav Calendar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,5 +17,8 @@
     "minimum-stability": "dev",
     "require-dev": {
         "phpunit/phpunit": "9.5.x-dev"
+    },
+    "require": {
+        "thecsea/simple-caldav-client": "dev-master"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,58 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3848deeaee8c80c327ea854bd565a52a",
-    "packages": [],
+    "content-hash": "934c7895d48599a588cec3aa6d5c5f20",
+    "packages": [
+        {
+            "name": "thecsea/simple-caldav-client",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecsea/simpleCalDAV.git",
+                "reference": "542eda99c5a18c04b3701ebda9ce8d3eb0db7728"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecsea/simpleCalDAV/zipball/542eda99c5a18c04b3701ebda9ce8d3eb0db7728",
+                "reference": "542eda99c5a18c04b3701ebda9ce8d3eb0db7728",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-xml": "*",
+                "php": ">=5.3.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "it\\thecsea\\simple_caldav_client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "claudio cardinale",
+                    "email": "cardi@thecsea.it",
+                    "homepage": "http://thecsea.it"
+                }
+            ],
+            "description": "A simple and complete php caldav client",
+            "homepage": "http://www.thecsea.it",
+            "keywords": [
+                "CalDAV",
+                "Simple",
+                "client"
+            ],
+            "support": {
+                "source": "https://github.com/thecsea/simpleCalDAV/tree/v0.1.14"
+            },
+            "time": "2020-09-28T11:55:52+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
@@ -137,16 +187,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.12.0",
+            "version": "v4.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143"
+                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6608f01670c3cc5079e18c1dab1104e002579143",
-                "reference": "6608f01670c3cc5079e18c1dab1104e002579143",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
                 "shasum": ""
             },
             "require": {
@@ -187,9 +237,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.12.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
             },
-            "time": "2021-07-21T10:44:31+00:00"
+            "time": "2021-11-03T20:52:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -362,12 +412,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "c5ac781da36459457837159b308fe88912e07a78"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/c5ac781da36459457837159b308fe88912e07a78",
-                "reference": "c5ac781da36459457837159b308fe88912e07a78",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -410,9 +460,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2021-08-13T09:13:23+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -420,12 +470,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "7b2df704cbe99a7b0522c7d5d7b7c5ea61b196bb"
+                "reference": "2a7ec2a310e8dff274c8af3bf3005288f0b1b7f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/7b2df704cbe99a7b0522c7d5d7b7c5ea61b196bb",
-                "reference": "7b2df704cbe99a7b0522c7d5d7b7c5ea61b196bb",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2a7ec2a310e8dff274c8af3bf3005288f0b1b7f6",
+                "reference": "2a7ec2a310e8dff274c8af3bf3005288f0b1b7f6",
                 "shasum": ""
             },
             "require": {
@@ -463,37 +513,38 @@
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
                 "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.x"
             },
-            "time": "2021-08-20T10:47:25+00:00"
+            "time": "2021-11-09T20:01:14+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -528,9 +579,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -538,19 +589,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d96981c0d2718c56aea9eeb254d3159b808156c3"
+                "reference": "9f37d464d6bc3cf1b379f785b66a2ce77bf523a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d96981c0d2718c56aea9eeb254d3159b808156c3",
-                "reference": "d96981c0d2718c56aea9eeb254d3159b808156c3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f37d464d6bc3cf1b379f785b66a2ce77bf523a6",
+                "reference": "9f37d464d6bc3cf1b379f785b66a2ce77bf523a6",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -607,7 +658,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-17T14:56:04+00:00"
+            "time": "2021-11-06T06:50:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -856,12 +907,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0979089082b2506ad2e75fb221268018b9bb79eb"
+                "reference": "6bcc8e610a24b9d382da960199447f8c40ae08f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0979089082b2506ad2e75fb221268018b9bb79eb",
-                "reference": "0979089082b2506ad2e75fb221268018b9bb79eb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bcc8e610a24b9d382da960199447f8c40ae08f3",
+                "reference": "6bcc8e610a24b9d382da960199447f8c40ae08f3",
                 "shasum": ""
             },
             "require": {
@@ -877,7 +928,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -943,7 +994,7 @@
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/donate.html",
+                    "url": "https://phpunit.de/sponsors.html",
                     "type": "custom"
                 },
                 {
@@ -951,7 +1002,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-08-20T05:38:37+00:00"
+            "time": "2021-11-11T09:11:03+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1382,16 +1433,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -1440,14 +1491,14 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0"
             },
             "funding": [
                 {
@@ -1455,7 +1506,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1867,7 +1918,7 @@
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "3.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
@@ -1924,16 +1975,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1980,7 +2034,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/main"
             },
             "funding": [
                 {
@@ -1996,7 +2050,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2111,6 +2165,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "thecsea/simple-caldav-client": 20,
         "phpunit/phpunit": 20
     },
     "prefer-stable": false,

--- a/config/config.php
+++ b/config/config.php
@@ -194,10 +194,10 @@ define('MENU_COORDINATION', TRUE);
 define('EXTRA_HOURS_WARNING_TRIGGER', 50);
 
 /**
- * @name NO_FILL_EMAIL_DOMAIN
+ * @name COMPANY_DOMAIN
  * @global string Domain of the users pinged on the NO_FILL emails
  */
-define('NO_FILL_EMAIL_DOMAIN', "domain.com");
+define('COMPANY_DOMAIN', "domain.com");
 
 /**
  * @name NO_FILL_EMAIL_FROM
@@ -332,4 +332,3 @@ define('CALENDAR_URL', '');
 define('CALENDAR_ID', '');
 define('CALENDAR_USERNAME', '');
 define('CALENDAR_PASSWORD', '');
-define('COMPANY_DOMAIN', '');

--- a/config/config.php
+++ b/config/config.php
@@ -326,3 +326,10 @@ define('ISSUE_TRACKER_LINKS_URL',
  * To be used in combination with ISSUE_TRACKER_LINKS_URL, see its entry above.
  */
 define('ISSUE_TRACKER_LINKS_TEXT', serialize(array('Report an issue')));
+
+/* CalDav integration */
+define('CALENDAR_URL', '');
+define('CALENDAR_ID', '');
+define('CALENDAR_USERNAME', '');
+define('CALENDAR_PASSWORD', '');
+define('COMPANY_DOMAIN', '');

--- a/config/config.template
+++ b/config/config.template
@@ -194,10 +194,10 @@ define('MENU_COORDINATION', TRUE);
 define('EXTRA_HOURS_WARNING_TRIGGER', 50);
 
 /**
- * @name NO_FILL_EMAIL_DOMAIN
+ * @name COMPANY_DOMAIN
  * @global string Domain of the users pinged on the NO_FILL emails
  */
-define('NO_FILL_EMAIL_DOMAIN', "domain.com");
+define('COMPANY_DOMAIN', "domain.com");
 
 /**
  * @name NO_FILL_EMAIL_FROM
@@ -332,4 +332,3 @@ define('CALENDAR_URL', '');
 define('CALENDAR_ID', '');
 define('CALENDAR_USERNAME', '');
 define('CALENDAR_PASSWORD', '');
-define('COMPANY_DOMAIN', '');

--- a/config/config.template
+++ b/config/config.template
@@ -326,3 +326,10 @@ define('ISSUE_TRACKER_LINKS_URL',
  * To be used in combination with ISSUE_TRACKER_LINKS_URL, see its entry above.
  */
 define('ISSUE_TRACKER_LINKS_TEXT', serialize(array('Report an issue')));
+
+/* CalDav integration */
+define('CALENDAR_URL', '');
+define('CALENDAR_ID', '');
+define('CALENDAR_USERNAME', '');
+define('CALENDAR_PASSWORD', '');
+define('COMPANY_DOMAIN', '');

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -46,6 +46,7 @@ $permissions = array(
         //holidays management
         '/services/getHolidays.php',
         '/services/updateHolidays.php',
+        '/services/syncCalendar.php',
         '/holidayManagement.php',
         //templates
         '/services/createTemplatesService.php', '/services/getUserTemplatesService.php',

--- a/jobs/sendEmailAlertNoFill.php
+++ b/jobs/sendEmailAlertNoFill.php
@@ -35,7 +35,7 @@
 
     include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
     $ALL_USERS_GROUP = ConfigurationParametersManager::getParameter('ALL_USERS_GROUP');
-    $NO_FILL_EMAIL_DOMAIN = ConfigurationParametersManager::getParameter('NO_FILL_EMAIL_DOMAIN');
+    $COMPANY_DOMAIN = ConfigurationParametersManager::getParameter('COMPANY_DOMAIN');
     $NO_FILL_EMAIL_FROM = ConfigurationParametersManager::getParameter('NO_FILL_EMAIL_FROM');
     $NO_FILL_CC_CRITICAL = ConfigurationParametersManager::getParameter('NO_FILL_CC_CRITICAL');
     $NO_FILL_TEMPLATE_CRITICAL = ConfigurationParametersManager::getParameter('NO_FILL_TEMPLATE_CRITICAL');
@@ -90,7 +90,7 @@
             foreach ($groups as $group) {
                 if ($group->getName() == $ALL_USERS_GROUP) {
                     $login = $user->getLogin();
-                    $email = $login . "@" . $NO_FILL_EMAIL_DOMAIN;
+                    $email = $login . "@" . $COMPANY_DOMAIN;
                     $from = $NO_FILL_EMAIL_FROM;
                     $lastTaskDate = TasksFacade::getLastTaskDate($user, $today);
                     if (is_null($lastTaskDate)) {

--- a/model/facade/CalDAVCalendarFacade.php
+++ b/model/facade/CalDAVCalendarFacade.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Phpreport\Model\facade;
+
+include_once(PHPREPORT_ROOT . '/model/facade/action/SyncCalendarAction.php');
+
+abstract class CalDAVCalendarFacade
+{
+    static function SyncCalendar(\UserVO $userVO, array $datesRanges = [])
+    {
+        $action = new \SyncCalendarAction($userVO, $datesRanges);
+        return $action->execute();
+    }
+}

--- a/model/facade/action/SyncCalendarAction.php
+++ b/model/facade/action/SyncCalendarAction.php
@@ -46,6 +46,9 @@ class SyncCalendarAction extends Action
         $password = ConfigurationParametersManager::getParameter('CALENDAR_PASSWORD');
         $companyDomain = ConfigurationParametersManager::getParameter('COMPANY_DOMAIN');
 
+        if (!$url || !$calendarUser || !$password || !$companyDomain)
+            throw new Exception("CalDAV calendar not configured correctly");
+
         $client = new SimpleCalDAVClient();
 
         $client->connect($url, $calendarUser, $password);

--- a/model/facade/action/SyncCalendarAction.php
+++ b/model/facade/action/SyncCalendarAction.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+if (!defined('PHPREPORT_ROOT')) define('PHPREPORT_ROOT', __DIR__ . '/../../');
+require_once(PHPREPORT_ROOT . "/vendor/autoload.php");
+include_once(PHPREPORT_ROOT . '/model/facade/action/Action.php');
+include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
+
+use it\thecsea\simple_caldav_client\SimpleCalDAVClient;
+
+class SyncCalendarAction extends Action
+{
+    protected $user;
+    protected $datesRanges;
+
+    public function __construct(UserVO $user = NULL, array $datesRanges = [])
+    {
+        $this->user = $user;
+        $this->datesRanges = $datesRanges;
+        $this->preActionParameter = "SYNC_CALENDAR_PREACTION";
+        $this->postActionParameter = "SYNC_CALENDAR_POSTACTION";
+    }
+
+    protected function doExecute()
+    {
+        $url = ConfigurationParametersManager::getParameter('CALENDAR_URL');
+        $calendarUser = ConfigurationParametersManager::getParameter('CALENDAR_USERNAME');
+        $password = ConfigurationParametersManager::getParameter('CALENDAR_PASSWORD');
+        $companyDomain = ConfigurationParametersManager::getParameter('COMPANY_DOMAIN');
+
+        $client = new SimpleCalDAVClient();
+
+        $client->connect($url, $calendarUser, $password);
+        $arrayOfCalendars = $client->findCalendars();
+
+        $client->setCalendar($arrayOfCalendars[ConfigurationParametersManager::getParameter('CALENDAR_ID')]);
+
+        $lastYear = date("Y") - 1;
+        $nextYear = date("Y") + 1;
+        $start = gmdate("Ymd\THis\Z", strtotime($lastYear . "-01-01"));
+        $end = gmdate("Ymd\THis\Z", strtotime($nextYear . "-12-31"));
+        $currentEvents = $client->getEvents($start, $end);
+        foreach ($currentEvents as $event) {
+            if (strstr($event->getData(), $this->user->getLogin() . "-phpreport")) {
+                $client->delete($event->getHref());
+            }
+        }
+
+        foreach ($this->datesRanges as $range) {
+            if (!is_array($range) || !isset($range['start'])) continue;
+
+            $start = str_replace("-", "", $range['start']);
+            $end = str_replace("-", "", $range['end']);
+            $event = "BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Igalia PhPReport//CalDAV Client//EN
+BEGIN:VEVENT
+UID:" . $start . "-" . $this->user->getLogin() . "-phpreport
+CLASS:PUBLIC
+DTSTAMP:" . $start . "
+DTSTART;VALUE=DATE:" . $start . "
+DTEND;VALUE=DATE:" . $end . "
+SUMMARY:" . $this->user->getLogin() . " on leave
+ORGANIZER:" . $this->user->getLogin() . "@" . $companyDomain . "
+ATTENDEE:" . $this->user->getLogin() . "@" . $companyDomain . "
+DESCRIPTION:Event created automatically from PhpReport
+END:VEVENT
+END:VCALENDAR";
+
+            $client->create($event);
+        }
+    }
+}

--- a/model/facade/action/SyncCalendarAction.php
+++ b/model/facade/action/SyncCalendarAction.php
@@ -78,7 +78,7 @@ CLASS:PUBLIC
 DTSTAMP:" . $start . "
 DTSTART;VALUE=DATE:" . $start . "
 DTEND;VALUE=DATE:" . $end . "
-SUMMARY:" . $this->user->getLogin() . " on leave
+SUMMARY:" . $this->user->getLogin() . " holiday
 ORGANIZER:" . $this->user->getLogin() . "@" . $companyDomain . "
 ATTENDEE:" . $this->user->getLogin() . "@" . $companyDomain . "
 DESCRIPTION:Event created automatically from PhpReport

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -86,7 +86,6 @@ include_once("include/header.php");
                         <strong>TIP:</strong> Double click on single dates if you want to delete existing holidays.
                     </p>
                     <p class="text-center">
-                        <button class="btn" ref="syncBtn" v-on:click="syncCalendar">Sync with Sogo</button>
                         <button class="btn" ref="saveBtn" v-on:click="onSaveClick">Save Holidays</button>
                     </p>
                 </div>

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -85,8 +85,9 @@ include_once("include/header.php");
                     <p class="warning info">
                         <strong>TIP:</strong> Double click on single dates if you want to delete existing holidays.
                     </p>
-                    <p class="text-right">
-                        <button class="btn" v-on:click="onSaveClick">Save Holidays</button>
+                    <p class="text-center">
+                        <button class="btn" ref="syncBtn" v-on:click="syncCalendar">Sync with Sogo</button>
+                        <button class="btn" ref="saveBtn" v-on:click="onSaveClick">Save Holidays</button>
                     </p>
                 </div>
             </div>

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -103,10 +103,10 @@ include_once("include/header.php");
         </div>
         <div class="calendar">
             <div v-if="isEditing">
-                <v-date-picker ref="calendar" :from-page="fromPage" is-range v-model="range" :attributes="ranges" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :select-attribute="selectAttribute" @dayclick="onDayClick" @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
+                <v-date-picker ref="calendar" is-expanded :from-page="fromPage" is-range v-model="range" :attributes="ranges" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers :select-attribute="selectAttribute" @dayclick="onDayClick" @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
             <div v-show="!isEditing">
-                <v-calendar is-range :from-page="fromPage" v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
+                <v-calendar is-range is-expanded :from-page="fromPage" v-model="teamRange" :attributes="teamAttributes" :first-day-of-week="2" :rows="3" :columns="$screens({ default: 2, lg: 4 })" show-iso-weeknumbers @update:from-page="updateCurrentYear" :min-date="init" :max-date="end" />
             </div>
         </div>
         <div class="snackbarWrapper">

--- a/web/include/calendar.css
+++ b/web/include/calendar.css
@@ -8,7 +8,7 @@
 
 @media (min-width: 960px) {
     .holidayContainer {
-        grid-template-columns: 22% 78%;
+        grid-template-columns: 25% 75%;
     }
 }
 

--- a/web/include/phpreport.css
+++ b/web/include/phpreport.css
@@ -104,6 +104,11 @@ div#tasks textarea {
     color: #0f60ca;
 }
 
+.btn:disabled {
+    color: #ccc;
+    cursor: default;
+}
+
 .snackbarWrapper {
     position: fixed;
     bottom: 1em;

--- a/web/include/phpreport.css
+++ b/web/include/phpreport.css
@@ -84,8 +84,12 @@ div#tasks textarea {
     text-align: right;
 }
 
+.text-center {
+    text-align: center;
+}
+
 .btn {
-    padding: 10px 15px;
+    padding: 10px;
     background-color: #fff;
     border-radius: 5px;
     border: 1px solid #ccc;
@@ -93,6 +97,7 @@ div#tasks textarea {
     box-shadow: 2px 2px 2px #eee;
     text-transform: uppercase;
     font-weight: bold;
+    margin: 2px;
 }
 
 .btn:hover {

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -341,6 +341,8 @@ var app = new Vue({
             }
         },
         onSaveClick: async function () {
+            this.toggleDisableButtons();
+
             const url = `services/updateHolidays.php?init=${formatDate(this.init)}&end=${formatDate(this.end)}`;
             const res = await fetch(url, {
                 method: 'POST',
@@ -377,8 +379,10 @@ var app = new Vue({
                     this.serverMessages.push({ classes: "message success", text: "Holidays were updated." });
                 }
             };
-            this.fetchSummary();
-            this.$emit('flush-message')
+            await this.fetchSummary();
+            this.syncCalendar();
+            this.toggleDisableButtons();
+            this.$emit('flush-message');
         },
         onSelectUser(userIndex) {
             if (!this.usersList[userIndex]) return;
@@ -432,7 +436,6 @@ var app = new Vue({
             this.usersList = this.users.filter(user => user.name.toLowerCase().includes(event.target.value.toLowerCase()));
         },
         toggleDisableButtons() {
-            this.$refs.syncBtn.disabled = !this.$refs.syncBtn.disabled;
             this.$refs.saveBtn.disabled = !this.$refs.saveBtn.disabled;
         },
         syncCalendar: async function () {
@@ -446,10 +449,6 @@ var app = new Vue({
                     }
                 }
             });
-            this.toggleDisableButtons();
-
-            // Save holidays to make sure we keep everything on sync
-            await this.onSaveClick();
 
             const res = await fetch(url, {
                 method: 'POST',
@@ -463,17 +462,11 @@ var app = new Vue({
                 body: JSON.stringify(ranges)
             });
 
-            this.toggleDisableButtons();
             const body = await res.json();
             if ("error" in body) {
                 this.serverMessages.push({
                     classes: 'message error',
                     text: body.error
-                });
-            } else {
-                this.serverMessages.push({
-                    classes: 'message success',
-                    text: body.message
                 });
             }
         }

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -438,7 +438,7 @@ var app = new Vue({
         syncCalendar: async function () {
             const url = `services/syncCalendar.php?init=${formatDate(this.init)}&end=${formatDate(this.end)}`;
             const ranges = this.ranges.map(range => {
-                if (range.coveredDates) {
+                if (range.coveredDates && range.dates.start) {
                     const end = addDays(range.dates.end, 1);
                     return {
                         start: formatDate(range.dates.start),

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -20,6 +20,8 @@
 
 namespace Phpreport\Web\services;
 
+use Phpreport\Model\facade;
+
 if (!defined('PHPREPORT_ROOT')) define('PHPREPORT_ROOT', __DIR__ . '/../../');
 
 include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
@@ -290,5 +292,23 @@ class HolidayService
             "resultCreation" => $resultCreation,
             "resultDeleted" => $resultDeleted
         ];
+    }
+
+    public function syncCalDAVCalendar(array $datesRanges = [])
+    {
+        if (!$this->loginManager::isLogged()) {
+            return ['error' => 'User not logged in'];
+        }
+
+        if (!$this->loginManager::isAllowed()) {
+            return ['error' => 'Forbidden service for this User'];
+        }
+
+        $userVO = new \UserVO();
+        $userVO->setLogin($_SESSION['user']->getLogin());
+        $userVO->setId($_SESSION['user']->getId());
+
+        facade\CalDAVCalendarFacade::SyncCalendar($userVO, $datesRanges);
+        return ['message' => 'Calendar synced'];
     }
 }

--- a/web/services/syncCalendar.php
+++ b/web/services/syncCalendar.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phpreport\Web\services\HolidayService;
+
+define('PHPREPORT_ROOT', __DIR__ . '/../../');
+
+require_once(PHPREPORT_ROOT . "/vendor/autoload.php");
+require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
+
+$userLogin = $_GET['userLogin'] ?? NULL;
+$loginManager = new \LoginManager();
+$holidayService = new HolidayService($loginManager);
+
+$datesRanges = json_decode(file_get_contents('php://input'), true);
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $result = $holidayService->syncCalDAVCalendar($datesRanges);
+    if (array_key_exists('error', $result)) {
+        // user is logged out or doesn't have permission
+        http_response_code(403);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    $result = ['error' => "An error happened while syncing the calendar"];
+}
+
+echo json_encode($result);

--- a/web/services/syncCalendar.php
+++ b/web/services/syncCalendar.php
@@ -41,7 +41,9 @@ try {
     }
 } catch (Exception $e) {
     http_response_code(500);
-    $result = ['error' => "An error happened while syncing the calendar"];
+    $msg = $e->getMessage() == "CalDAV calendar not configured correctly" ?
+        $e->getMessage() : "An error happened while syncing the calendar";
+    $result = ['error' => $msg];
 }
 
 echo json_encode($result);


### PR DESCRIPTION
Adds a button in the calendar view that allows the user to sync their PhpReport holidays with a CalDav Calendar.

To test and deploy this one it will be needed to run `composer install` again since we added an external [package](https://packagist.org/packages/thecsea/simple-caldav-client) to handle the CalDav requests.

There are also a few new config variables that need to be filled in order for it to work:
```
define('CALENDAR_URL', '');
define('CALENDAR_ID', '');
define('CALENDAR_USERNAME', '');
define('CALENDAR_PASSWORD', '');
define('COMPANY_DOMAIN', '');
```