### PR TITLE
Filter active users in the Team calendar

### DIFF
--- a/model/facade/UsersFacade.php
+++ b/model/facade/UsersFacade.php
@@ -33,6 +33,7 @@ include_once(PHPREPORT_ROOT . '/model/facade/action/CreateUserAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/DeleteUserAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetUserAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetAllUsersAction.php');
+include_once(PHPREPORT_ROOT . '/model/facade/action/GetAllActiveUsersAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetUsersByAreaIdDateAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/GetUserByLoginAction.php');
 include_once(PHPREPORT_ROOT . '/model/facade/action/UpdateUserAction.php');
@@ -158,6 +159,11 @@ abstract class UsersFacade {
 
     return $action->execute();
 
+    }
+
+    static function GetAllActiveUsers() {
+        $action = new GetAllActiveUsersAction();
+        return $action->execute();
     }
 
     /** Create User Function

--- a/model/facade/action/GetAllActiveUsersAction.php
+++ b/model/facade/action/GetAllActiveUsersAction.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+include_once(PHPREPORT_ROOT . '/model/facade/action/Action.php');
+include_once(PHPREPORT_ROOT . '/model/dao/DAOFactory.php');
+include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
+
+class GetAllActiveUsersAction extends Action{
+    public function __construct() {
+        $this->preActionParameter="GET_ALL_ACTIVE_USERS_PREACTION";
+        $this->postActionParameter="GET_ALL_ACTIVE_USERS_POSTACTION";
+    }
+
+    protected function doExecute() {
+        $groupDAO = DAOFactory::getUserGroupDAO();
+        return $groupDAO->getUsersByUserGroupName(ConfigurationParametersManager::getParameter("ALL_USERS_GROUP"));
+    }
+}

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -200,7 +200,7 @@ var app = new Vue({
             }
         },
         async fetchUsers() {
-            const url = `services/getAllUsersService.php`;
+            const url = `services/getAllUsersService.php?active=true`;
             const res = await fetch(url, {
                 method: 'GET',
                 mode: 'same-origin',

--- a/web/services/getAllUsersService.php
+++ b/web/services/getAllUsersService.php
@@ -53,8 +53,7 @@
 
         if ($active == "true")
         {
-            $groupDAO = DAOFactory::getUserGroupDAO();
-            $users = $groupDAO->getUsersByUserGroupName(ConfigurationParametersManager::getParameter("ALL_USERS_GROUP"));
+            $users = UsersFacade::GetAllActiveUsers();
         }
         else
         {

--- a/web/services/getAllUsersService.php
+++ b/web/services/getAllUsersService.php
@@ -28,10 +28,12 @@
 
     define('PHPREPORT_ROOT', __DIR__ . '/../../');
     include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
+    include_once(PHPREPORT_ROOT . '/model/dao/DAOFactory.php');
     include_once(PHPREPORT_ROOT . '/model/facade/UsersFacade.php');
     include_once(PHPREPORT_ROOT . '/model/vo/UserVO.php');
 
     $sid = $_GET['sid'] ?? NULL;
+    $active = $_GET['active'] ?? NULL;
 
     do {
         /* We check authentication and authorization */
@@ -49,7 +51,15 @@
             break;
         }
 
-        $users = UsersFacade::GetAllUsers();
+        if ($active == "true")
+        {
+            $groupDAO = DAOFactory::getUserGroupDAO();
+            $users = $groupDAO->getUsersByUserGroupName(ConfigurationParametersManager::getParameter("ALL_USERS_GROUP"));
+        }
+        else
+        {
+            $users = UsersFacade::GetAllUsers();
+        }
 
         $string = "<users>";
 


### PR DESCRIPTION
List only users that belong to `ALL_USERS_GROUP`. This means that
they are active in the company and therefore this will hide inactive users.

Fixes https://github.com/Igalia/phpreport/issues/542