### PR TITLE
Consider partial leaves when grouping by week

### DIFF
--- a/tests/web/services/HolidayServiceTest.php
+++ b/tests/web/services/HolidayServiceTest.php
@@ -158,12 +158,48 @@ class HolidayServiceTest extends TestCase
     public function testGroupByWeeksSameYear(): void
     {
         $dates = [
-            "2021-10-14",
-            "2021-10-15",
-            "2021-11-01"
+            "2021-10-14" => [
+                "init" => 0,
+                "end" => 420,
+            ],
+            "2021-10-15" => [
+                "init" => 0,
+                "end" => 420,
+            ],
+            "2021-11-01" => [
+                "init" => 0,
+                "end" => 420,
+            ]
         ];
         $result = [
             '2021W41' => 2,
+            '2021W44' => 1
+        ];
+        $this->assertEquals(
+            $result,
+            $this->instance::groupByWeeks($dates)
+        );
+    }
+
+    public function testGroupByWeeksWithPartialLeaves(): void
+    {
+        $dates = [
+            "2021-10-14" => [
+                "init" => 0,
+                "end" => 210,
+                "amount" => 0.5
+            ],
+            "2021-10-15" => [
+                "init" => 0,
+                "end" => 420,
+            ],
+            "2021-11-01" => [
+                "init" => 0,
+                "end" => 420,
+            ]
+        ];
+        $result = [
+            '2021W41' => 1.5,
             '2021W44' => 1
         ];
         $this->assertEquals(
@@ -177,9 +213,18 @@ class HolidayServiceTest extends TestCase
         // The first week of 2021 doesn't belong to the ISO week one of 2021,
         // instead it belongs to the last week (53) of 2020
         $dates = [
-            "2021-01-01",
-            "2021-01-02",
-            "2021-11-01"
+            "2021-01-01" =>  [
+                "init" => 0,
+                "end" => 420,
+            ],
+            "2021-01-02" =>  [
+                "init" => 0,
+                "end" => 420,
+            ],
+            "2021-11-01" =>  [
+                "init" => 0,
+                "end" => 420,
+            ],
         ];
         $result = [
             '2020W53' => 2,

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -150,17 +150,18 @@ class HolidayService
         return $formatedHours;
     }
 
-    static function groupByWeeks(array $dates): array
+    static function groupByWeeks(array $leavesDetails, $weeks = []): array
     {
-        if (count($dates) == 0) return [];
+        if (count($leavesDetails) == 0) return [];
+        $dates = array_keys($leavesDetails);
         $previous_week = date("o\WW", strtotime($dates[0]));
-        $weeks[$previous_week] = 1;
+        $weeks[$previous_week] = $leavesDetails[$dates[0]]['amount'] ?? 1;
         for ($i = 1; $i < count($dates); $i++) {
             $current_week = date("o\WW", strtotime($dates[$i]));
             if ($current_week == $previous_week) {
-                $weeks[$current_week]++;
+                $weeks[$current_week] += $leavesDetails[$dates[$i]]['amount'] ?? 1;
             } else {
-                $weeks[$current_week] = 1;
+                $weeks[$current_week] = $leavesDetails[$dates[$i]]['amount'] ?? 1;
                 $previous_week = $current_week;
             }
         }
@@ -175,6 +176,7 @@ class HolidayService
             $validJourney = array_pop($validJourney);
             if (($validJourney->getJourney() * 60) > ($duration['end'] - $duration['init'])) {
                 $dates[$day]['isPartialLeave'] = True;
+                $dates[$day]['amount'] = round((($duration['end'] - $duration['init']) / ($validJourney->getJourney() * 60)), 2);
             }
         }
         return $dates;
@@ -204,7 +206,7 @@ class HolidayService
         return [
             'dates' => $vacations,
             'ranges' => $this->datesToRanges(array_keys($vacations)),
-            'weeks' => $this->groupByWeeks(array_keys($vacations))
+            'weeks' => $this->groupByWeeks($vacations)
         ];
     }
 


### PR DESCRIPTION
Instead of counting as a full day every day that has a leave,
proportionate when there are partial leaves in the week.

This was causing some confusion because the sum was always
considering each day that had a leave as 1 and creating
unprecise numbers.

Note that one day is the user journey at the time the page was
rendered.

Fixes https://github.com/Igalia/phpreport/issues/543