### PR TITLE
Fix null access to $oldTask.

### DIFF
--- a/model/facade/action/PartialUpdateTasksAction.php
+++ b/model/facade/action/PartialUpdateTasksAction.php
@@ -92,9 +92,15 @@ class PartialUpdateTasksAction extends Action{
                 }
             }
 
+            $oldTask = $taskDao->getById($task->getId());
+            if (!isset($oldTask)) {
+                $discardedTasks[] = $task;
+                unset($this->tasks[$i]);
+                continue;
+            }
+
             // Do not allow updating tasks saved in locked dates or belonging
             // to a different user
-            $oldTask = $taskDao->getById($task->getId());
             if(!$configDao->isWriteAllowedForDate($oldTask->getDate()) ||
                     (!$taskDao->checkTaskUserId(
                         $task->getId(), $task->getUserId()))) {


### PR DESCRIPTION
In case there was no task for the specified ID, the code would break. Now we check if it exists before actually using the returning object.