### PR TITLE
Create task type backend service

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -43,6 +43,7 @@ $permissions = array(
         '/services/createTasksService.php', '/services/deleteTasksService.php',
         '/services/updateTasksService.php',
         '/services/getTasksFiltered.php', '/userTasksReport.php',
+        '/services/getTaskTypes.php',
         //holidays management
         '/services/getHolidays.php',
         '/services/updateHolidays.php',

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -95,33 +95,16 @@ var templateRecord = new Ext.data.Record.create([
 ]);
 
 /* Available values and display names for the `taskType` field in tasks */
-var taskTypeStore = new Ext.data.ArrayStore({
+var taskTypeStore = new Ext.data.JsonStore({
     fields: [
         'value',
         'displayText'
     ],
-    data: [
-        ['administration', 'Administration'],
-        ['analysis', 'Analysis'],
-        ['community', 'Community'],
-        ['coordination', 'Coordination'],
-        ['demonstration', 'Demonstration'],
-        ['deployment', 'Deployment'],
-        ['design', 'Design'],
-        ['documentation', 'Documentation'],
-        ['environment', 'Environment'],
-        ['implementation', 'Implementation'],
-        ['maintenance', 'Maintenance'],
-        ['publication', 'Publication'],
-        ['requirements', 'Requirements'],
-        ['sales', 'Sales'],
-        ['sys_maintenance', 'Systems maintenance'],
-        ['teaching', 'Teaching'],
-        ['technology', 'Technology'],
-        ['test', 'Test'],
-        ['training', 'Training'],
-        ['traveling', 'Traveling'],
-    ],
+    root: 'records',
+    idProperty: 'value',
+    successProperty: 'success',
+    url: 'services/getTaskTypes.php',
+    autoLoad: 'true',
 });
 
 /* Variable to store if all tasks has loaded completely for a day */

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -93,6 +93,37 @@ var templateRecord = new Ext.data.Record.create([
     {name:'initTime'},
     {name:'endTime'}
 ]);
+
+/* Available values and display names for the `taskType` field in tasks */
+var taskTypeStore = new Ext.data.ArrayStore({
+    fields: [
+        'value',
+        'displayText'
+    ],
+    data: [
+        ['administration', 'Administration'],
+        ['analysis', 'Analysis'],
+        ['community', 'Community'],
+        ['coordination', 'Coordination'],
+        ['demonstration', 'Demonstration'],
+        ['deployment', 'Deployment'],
+        ['design', 'Design'],
+        ['documentation', 'Documentation'],
+        ['environment', 'Environment'],
+        ['implementation', 'Implementation'],
+        ['maintenance', 'Maintenance'],
+        ['publication', 'Publication'],
+        ['requirements', 'Requirements'],
+        ['sales', 'Sales'],
+        ['sys_maintenance', 'Systems maintenance'],
+        ['teaching', 'Teaching'],
+        ['technology', 'Technology'],
+        ['test', 'Test'],
+        ['training', 'Training'],
+        ['traveling', 'Traveling'],
+    ],
+});
+
 /* Variable to store if all tasks has loaded completely for a day */
 var loaded = false;
 
@@ -532,34 +563,7 @@ var TaskPanel = Ext.extend(Ext.Panel, {
                 typeAhead: true,
                 triggerAction: 'all',
                 forceSelection: true,
-                store: new Ext.data.ArrayStore({
-                    fields: [
-                        'value',
-                        'displayText'
-                    ],
-                    data: [
-                        ['administration', 'Administration'],
-                        ['analysis', 'Analysis'],
-                        ['community', 'Community'],
-                        ['coordination', 'Coordination'],
-                        ['demonstration', 'Demonstration'],
-                        ['deployment', 'Deployment'],
-                        ['design', 'Design'],
-                        ['documentation', 'Documentation'],
-                        ['environment', 'Environment'],
-                        ['implementation', 'Implementation'],
-                        ['maintenance', 'Maintenance'],
-                        ['publication', 'Publication'],
-                        ['requirements', 'Requirements'],
-                        ['sales', 'Sales'],
-                        ['sys_maintenance', 'Systems maintenance'],
-                        ['teaching', 'Teaching'],
-                        ['technology', 'Technology'],
-                        ['test', 'Test'],
-                        ['training', 'Training'],
-                        ['traveling', 'Traveling'],
-                    ],
-                }),
+                store: taskTypeStore,
                 listeners: {
                     'select': function () {
                         this.parent.taskRecord.set('ttype',this.getValue());

--- a/web/js/userTasksReport.js
+++ b/web/js/userTasksReport.js
@@ -120,34 +120,16 @@ Ext.onReady(function () {
     });
 
     /* Store object and data for task types */
-    var taskTypeStore = new Ext.data.ArrayStore({
-        idIndex: 0,
+    var taskTypeStore = new Ext.data.JsonStore({
         fields: [
             'value',
             'displayText'
         ],
-        data: [
-            ['administration', 'Administration'],
-            ['analysis', 'Analysis'],
-            ['community', 'Community'],
-            ['coordination', 'Coordination'],
-            ['demonstration', 'Demonstration'],
-            ['deployment', 'Deployment'],
-            ['design', 'Design'],
-            ['documentation', 'Documentation'],
-            ['environment', 'Environment'],
-            ['implementation', 'Implementation'],
-            ['maintenance', 'Maintenance'],
-            ['publication', 'Publication'],
-            ['requirements', 'Requirements'],
-            ['sales', 'Sales'],
-            ['sys_maintenance', 'Systems maintenance'],
-            ['teaching', 'Teaching'],
-            ['technology', 'Technology'],
-            ['test', 'Test'],
-            ['training', 'Training'],
-            ['traveling', 'Traveling'],
-        ],
+        root: 'records',
+        idProperty: 'value',
+        successProperty: 'success',
+        url: 'services/getTaskTypes.php',
+        autoLoad: 'true',
     });
 
     /* Renderer to show the project name in the grid */

--- a/web/services/getTaskTypes.php
+++ b/web/services/getTaskTypes.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * Copyright (C) 2022 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+define('PHPREPORT_ROOT', __DIR__ . '/../../');
+
+do {
+    $response = array();
+
+    /* We check authentication and authorization */
+    require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
+
+    if (!LoginManager::isLogged($sid))
+    {
+        if ($init!="")
+            $response['init'] = $init;
+        if ($end!="")
+            $response['end'] = $end;
+        $response['success'] = false;
+        $error['id'] = 2;
+        $error['message'] = "You must be logged in";
+        $response['error'] = $error;
+        break;
+    }
+
+    if (!LoginManager::isAllowed($sid))
+    {
+        if ($init!="")
+            $response['init'] = $init;
+        if ($end!="")
+            $response['end'] = $end;
+        $response['success'] = false;
+        $error['id'] = 3;
+        $error['message'] = "Forbidden service for this User";
+        $response['error'] = $error;
+        break;
+    }
+
+    // Hard-coded data
+    $response['success'] = true;
+    $response['records'] = array(
+        array('value' => 'administration',  'displayText' => 'Administration'),
+        array('value' => 'analysis',        'displayText' => 'Analysis'),
+        array('value' => 'community',       'displayText' => 'Community'),
+        array('value' => 'coordination',    'displayText' => 'Coordination'),
+        array('value' => 'demonstration',   'displayText' => 'Demonstration'),
+        array('value' => 'deployment',      'displayText' => 'Deployment'),
+        array('value' => 'design',          'displayText' => 'Design'),
+        array('value' => 'documentation',   'displayText' => 'Documentation'),
+        array('value' => 'environment',     'displayText' => 'Environment'),
+        array('value' => 'implementation',  'displayText' => 'Implementation'),
+        array('value' => 'maintenance',     'displayText' => 'Maintenance'),
+        array('value' => 'publication',     'displayText' => 'Publication'),
+        array('value' => 'requirements',    'displayText' => 'Requirements'),
+        array('value' => 'sales',           'displayText' => 'Sales'),
+        array('value' => 'sys_maintenance', 'displayText' => 'Systems maintenance'),
+        array('value' => 'teaching',        'displayText' => 'Teaching'),
+        array('value' => 'technology',      'displayText' => 'Technology'),
+        array('value' => 'test',            'displayText' => 'Test'),
+        array('value' => 'training',        'displayText' => 'Training'),
+        array('value' => 'traveling',       'displayText' => 'Traveling'),
+    );
+
+} while (False);
+
+header('Content-type: application/json');
+
+// make it into a proper Json document with header etc
+$json = json_encode($response);
+
+// output correctly formatted Json
+echo $json;


### PR DESCRIPTION
So far, values for "task type" were hard-coded in two places in the    application front-end. Now they are still hard-coded, but in one    place in the remote, which makes them easier to modify. This will    ease the migration towards a solution where the values would be    stored in DB (e.g. for #325).

This is also useful for external applications using the phpreport API, so they don't need to hard-code the available values for task type.
