### PR TITLE
Vacation Summary: Add Used column

### DIFF
--- a/model/facade/action/GetHolidaySummaryReportAction.php
+++ b/model/facade/action/GetHolidaySummaryReportAction.php
@@ -39,7 +39,7 @@ class GetHolidaySummaryReportAction extends GetHolidayHoursBaseAction
     protected function doExecute()
     {
         $summary = $this->getHoursSummary($this->referenceDate);
-
+        $today = new DateTime(date('Y-m-d'));
         $journeyHistories = \UsersFacade::GetUserJourneyHistories($this->user->getLogin());
         $startDate = array_map(fn ($history) => $history->getInitDate(), $journeyHistories);
         $startDate = $startDate && min($startDate)->format('Y') == date("Y") ? date_format(min($startDate), 'Y-m-d') : '';
@@ -53,6 +53,12 @@ class GetHolidaySummaryReportAction extends GetHolidayHoursBaseAction
             $this->end,
             $this->user,
             $this->end
+        );
+        $summaryForToday = \UsersFacade::GetHolidayHoursSummary(
+            $this->init,
+            $this->end,
+            $this->user,
+            $today
         );
         $validJourney = array_filter(
             $journeyHistories,
@@ -78,8 +84,9 @@ class GetHolidaySummaryReportAction extends GetHolidayHoursBaseAction
             'user' => $this->user->getLogin(),
             'area' => $currentArea ?? '',
             'availableHours' => round($summary['availableHours'][$this->user->getLogin()], 2),
+            'usedHours' => round($summaryForToday['usedHours'][$this->user->getLogin()], 2),
             'pendingHours' => round($summary['pendingHours'][$this->user->getLogin()], 2),
-            'usedHours' => round($summary['usedHours'][$this->user->getLogin()], 2),
+            'plannedHours' => round($summary['usedHours'][$this->user->getLogin()], 2),
             'percentage' =>  $summary['availableHours'][$this->user->getLogin()] ? round(($summary['usedHours'][$this->user->getLogin()] / $summary['availableHours'][$this->user->getLogin()]) * 100, 2) : 0,
             'hoursDay' => $validJourney,
             'holidays' => $leaves,

--- a/web/holidaySummary.php
+++ b/web/holidaySummary.php
@@ -59,8 +59,9 @@ include_once("include/header.php");
                 <th>Area</th>
                 <th>Hours/day</th>
                 <th>Available (hours)</th>
+                <th>Used (hours)</th>
+                <th>Scheduled (hours)</th>
                 <th>Pending (hours)</th>
-                <th>Planned (hours)</th>
                 <th>% planned</th>
                 <th v-for="week in weeks" :key="week">{{week}}</th>
             </thead>
@@ -70,8 +71,9 @@ include_once("include/header.php");
                     <td>{{ row.area }}</td>
                     <td>{{ row.hoursDay }}</td>
                     <td>{{ row.availableHours }}</td>
-                    <td>{{ row.pendingHours }}</td>
                     <td>{{ row.usedHours }}</td>
+                    <td>{{ row.plannedHours }}</td>
+                    <td>{{ row.pendingHours }}</td>
                     <td :class="{ 'alert': row.percentage < 50}">{{row.percentage}}</td>
                     <td v-for="(userWeek, index) in row.holidays" :key="row.user + '-' + index" :class="{ 'highlight': userWeek > 0}">{{userWeek}}</td>
                 </tr>

--- a/web/js/holidaySummary.js
+++ b/web/js/holidaySummary.js
@@ -151,7 +151,7 @@ var app = new Vue({
             if (!event.target.value) {
                 // reset list of users when no project is selected
                 this.displayData = this.rawData;
-                this.projectList = this.allProjects;
+                this.projectsList = this.allProjects;
             } else {
                 this.projectsList = this.allProjects.filter(project => project.name.toLowerCase().includes(event.target.value.toLowerCase()));
             }

--- a/web/services/getHolidaySummary.php
+++ b/web/services/getHolidaySummary.php
@@ -56,8 +56,9 @@ if (!$csvExport) {
             'Area',
             'Hours/day',
             'Available (hours)',
+            'Used (hours)',
+            'Scheduled (hours)',
             'Pending (hours)',
-            'Planned (hours)',
             '% planned'
         ),
         array_keys($usersAndWeeks["weeks"])
@@ -79,8 +80,9 @@ if (!$csvExport) {
                     $line["area"],
                     $line["hoursDay"],
                     $line["availableHours"],
-                    $line["pendingHours"],
                     $line["usedHours"],
+                    $line["plannedHours"],
+                    $line["pendingHours"],
                     $line["percentage"]
                 ),
                 $line["holidays"]


### PR DESCRIPTION
As per requests from users:
- add used column based on the date the report is generated
- reorder columns
- rename Planning to Scheduled to match the User Summary labels