### PR TITLE
Improve usability of user management screen

### DIFF
--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -399,9 +399,10 @@ Ext.onReady(function(){
                     echo "userGrid.deleteBtn.setDisabled(sm.getCount() < 1);";
         ?>
         historiesPanel.setDisabled(sm.getCount() != 1);
-        if ((sm.getCount() == 1) && (!historiesPanel.collapsed))
-            if (!sm.getSelected().phantom)
-                loadHistories(sm.getSelected().get('login'), sm.getSelected().get('id'));
+        if ((sm.getCount() == 1) && (!sm.getSelected().phantom)) {
+            loadHistories(sm.getSelected().get('login'), sm.getSelected().get('id'));
+            historiesPanel.expand();
+        }
     });
 
     function loadHistories(login, userId){

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -383,6 +383,8 @@ Ext.onReady(function(){
         listeners: {
             select: function (combo, record) {
                 usersStore.filter('login', record.data.login);
+                // After the store is filtered to one user, the grid will only have one row
+                userGrid.getSelectionModel().selectFirstRow();
             }
         }
     });

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -286,6 +286,9 @@ Ext.onReady(function(){
             direction: 'ASC',
         },
         listeners: {
+            'load': function() {
+                userGrid.getTopToolbar().getComponent('userFilter').focus();
+            },
             'write': function() {
                 App.setAlert(true, "Users Changes Saved");
             },
@@ -375,7 +378,8 @@ Ext.onReady(function(){
         fieldLabel: 'Filter',
         name: 'userFilter',
         xtype: 'combo',
-        autoSelect: false,
+        autoSelect: true,
+        typeAhead: true,
         mode: 'local',
         store: usersStore,
         valueField: 'id',

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -149,7 +149,6 @@ Ext.onReady(function(){
 
             ?>
 
-
             // super
             inlineEditionPanel.superclass.initComponent.call(this);
         },
@@ -334,31 +333,6 @@ Ext.onReady(function(){
             ?>
     ]);
 
-    var userFilterPanel = new Ext.FormPanel({
-        width: 350,
-        labelWidth: 70,
-        frame: true,
-        title: 'User Filter',
-        renderTo: 'content',
-        bodyStyle: 'padding: 5px 5px 0px 5px;',
-        items: [{
-            id: 'userFilter',
-            fieldLabel: 'Filter',
-            name: 'userFilter',
-            xtype: 'combo',
-            autoSelect: false,
-            mode: 'local',
-            store: usersStore,
-            valueField: 'id',
-            displayField: 'login',
-            listeners: {
-                select: function (combo, record) {
-                    usersStore.filter('login', record.data.login);
-                }
-            }
-        }]
-    });
-    userFilterPanel.getComponent('userFilter').focus();
 
     var usersEditor = new editor();
 
@@ -394,6 +368,23 @@ Ext.onReady(function(){
             this.getSelectionModel().selectRow(0);
             this.inlineEditor.startEditing(0);
         },
+    });
+
+    userGrid.getTopToolbar().add('Filter:', {
+        id: 'userFilter',
+        fieldLabel: 'Filter',
+        name: 'userFilter',
+        xtype: 'combo',
+        autoSelect: false,
+        mode: 'local',
+        store: usersStore,
+        valueField: 'id',
+        displayField: 'login',
+        listeners: {
+            select: function (combo, record) {
+                usersStore.filter('login', record.data.login);
+            }
+        }
     });
 
     userGrid.getSelectionModel().on('selectionchange', function(sm){

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -1177,12 +1177,12 @@ Ext.onReady(function(){
         frame: false,
         plain: true,
         items:[
-            hourCostGrid,
             journeyGrid,
             areaGrid,
             cityGrid,
+            hourCostGrid,
             goalGrid
-            ]
+        ]
     });
 
     var historiesPanel = new Ext.Panel({


### PR DESCRIPTION
Some little tweaks to make this screen more pleasant to use:
* Move the recently added filter into the toolbar, which is less ugly.
* When users select a name from the filter, the corresponding row will be selected.
* The grid at the bottom will be expanded when a user is selected.
* The order of the panels was changed to better reflect their use.