### PR TITLE
Improve partial days text in vacation managementt

### DIFF
--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -254,7 +254,7 @@ var app = new Vue({
                         },
                         dates: new Date(d + 'T00:00:00'),
                         popover: {
-                            label: `Partial leave of ${duration}`
+                            label: `${duration} of vacation`
                         },
                         coveredDates: [d],
                     })


### PR DESCRIPTION
Improve the display of partial vacation days. "Leave" is a broader
category of PTO than "vacation," so using "vacation" here adds
some clarity.