### PR TITLE
Properly escape user-entered string data

### DIFF
--- a/web/projectDetailsReport.php
+++ b/web/projectDetailsReport.php
@@ -57,9 +57,9 @@ if(!LoginManager::hasExtraPermissions()) {
 echo "<!-- Global variables extracted from the PHP side -->\n";
 echo "<script>\n";
 echo "var projectData = {\n";
-echo "    description: '" . $project->getDescription() . "',\n";
+echo "    description: " . json_encode($project->getDescription()) . ",\n";
 echo "    id: " . $project->getId() . ",\n";
-echo "    customerName: '" . $project->getCustomerName() . "',\n";
+echo "    customerName: " . json_encode($project->getCustomerName()) . ",\n";
 echo "    estimatedHours: '" . $project->getEstHours() . "',\n";
 echo "    active: " . ($project->getActivation()? "true":"false") . ",\n";
 echo "    movedHours: '" . $project->getMovedHours() . "',\n";

--- a/web/projectManagement.php
+++ b/web/projectManagement.php
@@ -44,7 +44,8 @@ echo "<!-- Global variables extracted from the PHP side -->\n";
 echo "<script>\n";
 echo "var areasArray = [";
 foreach((array)$areas as $area) {
-    echo "[{$area->getId()}, '{$area->getName()}'],";
+    $areaName = json_encode($area->getName());
+    echo "[{$area->getId()}, {$areaName}],";
 }
 echo "];\n";
 echo "var customersArray = [";
@@ -59,7 +60,6 @@ echo "</script>\n";
 
 <div id="content">
 </div>
-<div id="variables"/>
 <?php
 /* Include the footer to close the header */
 include("include/footer.php");

--- a/web/services/createAreasService.php
+++ b/web/services/createAreasService.php
@@ -121,8 +121,11 @@
 
             $string = "<return service='createAreas'><ok>Operation Success!</ok><areas>";
 
-            foreach((array) $createAreas as $createArea)
-                $string = $string . "<area><id>{$createArea->getId()}</id><name>{$createArea->getName()}</name></area>";
+            foreach((array) $createAreas as $area)
+            {
+                $string .= "<area><id>{$area->getId()}</id>" .
+                    "<name>" . escape_string($area->getName()) . "</name></area>";
+            }
 
             $string = $string . "</areas></return>";
 

--- a/web/services/createCustomersService.php
+++ b/web/services/createCustomersService.php
@@ -151,8 +151,15 @@
 
             $string = "<return service='createCustomers'><ok>Operation Success!</ok><customers>";
 
-            foreach((array) $createCustomers as $createCustomer)
-                $string = $string . "<customer><id>{$createCustomer->getId()}</id><name>{$createCustomer->getName()}</name><sectorId>{$createCustomer->getSectorId()}</sectorId><type>{$createCustomer->getType()}</type><url>{$createCustomer->getUrl()}</url></customer>";
+            foreach((array) $createCustomers as $customer)
+            {
+                $string .= "<customer>" .
+                  "<id>{$customer->getId()}</id>" .
+                  "<sectorId>{$customer->getSectorId()}</sectorId>" .
+                  "<name>" . escape_string($customer->getName()) . "</name>" .
+                  "<type>{$customer->getType()}</type>" .
+                  "<url>" . escape_string($customer->getUrl()) ."</url></customer>";
+            }
 
             $string = $string . "</customers></return>";
 

--- a/web/services/createSectorsService.php
+++ b/web/services/createSectorsService.php
@@ -124,8 +124,12 @@
 
             $string = "<return service='createSectors'><ok>Operation Success!</ok><sectors>";
 
-            foreach((array) $createSectors as $createSector)
-                $string = $string . "<sector><id>{$createSector->getId()}</id><name>{$createSector->getName()}</name></sector>";
+            foreach((array) $createSectors as $sector)
+            {
+                $string .= "<sector><id>{$sector->getId()}</id>" .
+                    "<name>" . escape_string($sector->getName()) . "</name>" .
+                    "</sector>";
+            }
 
             $string = $string . "</sectors></return>";
 

--- a/web/services/getUserCustomersService.php
+++ b/web/services/getUserCustomersService.php
@@ -91,9 +91,12 @@
 
         foreach((array) $customers as $customer)
         {
-
-        $string = $string . "<customer><id>{$customer->getId()}</id><sectorId>{$customer->getSectorId()}</sectorId><name>{$customer->getName()}</name><type>{$customer->getType()}</type><url>{$customer->getUrl()}</url></customer>";
-
+            $string .= "<customer>" .
+              "<id>{$customer->getId()}</id>" .
+              "<sectorId>{$customer->getSectorId()}</sectorId>" .
+              "<name>" . escape_string($customer->getName()) . "</name>" .
+              "<type>{$customer->getType()}</type>" .
+              "<url>" . escape_string($customer->getUrl()) ."</url></customer>";
         }
 
         $string = $string . "</customers>";

--- a/web/services/updateAreasService.php
+++ b/web/services/updateAreasService.php
@@ -130,8 +130,11 @@
 
             $string = "<return service='updateAreas'><ok>Operation Success!</ok><areas>";
 
-            foreach((array) $updateAreas as $updateArea)
-                $string = $string . "<area><id>{$updateArea->getId()}</id><name>{$updateArea->getName()}</name></area>";
+            foreach((array) $updateAreas as $area)
+            {
+                $string .= "<area><id>{$area->getId()}</id>" .
+                    "<name>" . escape_string($area->getName()) . "</name></area>";
+            }
 
             $string = $string . "</areas></return>";
 

--- a/web/services/updateCustomersService.php
+++ b/web/services/updateCustomersService.php
@@ -160,10 +160,17 @@
 
             $string = "<return service='updateCustomers'><ok>Operation Success!</ok><customers>";
 
-            foreach((array) $updateCustomers as $updateCustomer)
-                $string = $string . "<customer><id>{$updateCustomer->getId()}</id><name>{$updateCustomer->getName()}</name><sectorId>{$updateCustomer->getSectorId()}</sectorId><type>{$updateCustomer->getType()}</type><url>{$updateCustomer->getUrl()}</url></customer>";
+            foreach((array) $updateCustomers as $customer)
+            {
+                $string .= "<customer>" .
+                  "<id>{$customer->getId()}</id>" .
+                  "<sectorId>{$customer->getSectorId()}</sectorId>" .
+                  "<name>" . escape_string($customer->getName()) . "</name>" .
+                  "<type>{$customer->getType()}</type>" .
+                  "<url>" . escape_string($customer->getUrl()) ."</url></customer>";
+            }
 
-                $string = $string . "</customers></return>";
+            $string .= "</customers></return>";
 
         }
 

--- a/web/services/updateSectorsService.php
+++ b/web/services/updateSectorsService.php
@@ -133,8 +133,12 @@
 
             $string = "<return service='updateSectors'><ok>Operation Success!</ok><sectors>";
 
-            foreach((array) $updateSectors as $updateSector)
-                $string = $string . "<sector><id>{$updateSector->getId()}</id><name>{$updateSector->getName()}</name></sector>";
+            foreach((array) $updateSectors as $sector)
+            {
+                $string .= "<sector><id>{$sector->getId()}</id>" .
+                    "<name>" . escape_string($sector->getName()) . "</name>" .
+                    "</sector>";
+            }
 
             $string = $string . "</sectors></return>";
 

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -89,8 +89,10 @@ Ext.onReady(function(){
             data : [
     <?php
 
-        foreach((array)$areas as $area)
-            echo "[{$area->getId()}, '{$area->getName()}'],";
+        foreach((array)$areas as $area) {
+            $areaName = json_encode($area->getName());
+            echo "[{$area->getId()}, {$areaName}],";
+        }
 
     ?>]});
 


### PR DESCRIPTION
Properly escape project, area, sector and customer names and other string data entered by users, in the XML and JS we generate.

Fixes #564.