### PR TITLE
Enhance how we fetch the vacations project id

### DIFF
--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -621,8 +621,10 @@ class PostgreSQLTaskDAO extends TaskDAO{
 
     }
 
-    public function getVacationsDates(UserVO $userVO, int $projectId = NULL, DateTime $initDate = NULL, DateTime $endDate = NULL): array
+    public function getVacationsDates(UserVO $userVO, DateTime $initDate = NULL, DateTime $endDate = NULL): array
     {
+        $projectId = $this->getVacationsProjectId();
+
         if (is_null($projectId)) {
             return [];
         }

--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -577,12 +577,12 @@ class PostgreSQLTaskDAO extends TaskDAO{
 
     $resultAux = @pg_fetch_array($res);
 
-    $vacId = $resultAux['id'];
-
-    if(is_null($vacId)) {
+    if(!$resultAux) {
         //the project configured as VACATIONS_PROJECT doesn't exist
         return null;
     }
+
+    $vacId = $resultAux['id'];
 
     $sql = "SELECT usrid, SUM(_end-init)/60.0 AS add_hours FROM task WHERE projectid=" . $vacId ." AND usrid=" . $userVO->getId();
 

--- a/model/dao/TaskDAO/TaskDAO.php
+++ b/model/dao/TaskDAO/TaskDAO.php
@@ -258,7 +258,7 @@ abstract class TaskDAO extends BaseDAO{
      */
     public abstract function getVacations(UserVO $userVO, DateTime $initDate = NULL, DateTime $endDate = NULL);
 
-    public abstract function getVacationsDates(UserVO $userVO, int $projectId = NULL, DateTime $initDate = NULL, DateTime $endDate = NULL): array;
+    public abstract function getVacationsDates(UserVO $userVO, DateTime $initDate = NULL, DateTime $endDate = NULL): array;
 
     /** Task partial updater for PostgreSQL.
      *

--- a/model/facade/action/GetScheduledHolidaysAction.php
+++ b/model/facade/action/GetScheduledHolidaysAction.php
@@ -45,7 +45,6 @@ class GetScheduledHolidaysAction extends Action
 
         $taskDao = DAOFactory::getTaskDAO();
         $userDao = DAOFactory::getUserDAO();
-        $projectDao = DAOFactory::getProjectDAO();
 
         if (is_null($this->user)) {
             return [];
@@ -58,12 +57,10 @@ class GetScheduledHolidaysAction extends Action
         } else
             if (is_null($this->user->getId()))
             $this->user = $userDao->getByUserLogin($this->user->getLogin());
-
-        $projectId = $projectDao->getByDescription(ConfigurationParametersManager::getParameter('VACATIONS_PROJECT'));
         $reportInit = $this->init;
         $reportEnd = $this->end;
 
-        $vacations = $taskDao->getVacationsDates($this->user, $projectId, $reportInit, $reportEnd);
+        $vacations = $taskDao->getVacationsDates($this->user, $reportInit, $reportEnd);
 
         return $vacations;
     }


### PR DESCRIPTION
I started fixing a PHP warning and ended doing a bit of refactoring and optimization.

I extracted the code that calculates the vacations project id to its own function and reused it from `getVacations` and `getVacationsDates`. This also has the advantage of reducing the usage of the `VACATIONS_PROJECT` config parameter in case we want to get rid of it. We also cache the value for subsequent calls, it's useful for `getVacations` which we call several times in the same request.