### PR TITLE
Escape area names in project evaluation report.

### DIFF
--- a/web/projectsEvaluation.php
+++ b/web/projectsEvaluation.php
@@ -57,10 +57,12 @@ Ext.onReady(function(){
         data : [
         <?php
 
-        foreach((array)$areas as $area)
-            echo "[{$area->getId()}, '{$area->getName()}'],";
-
-    ?>]});
+        foreach((array)$areas as $area) {
+            $areaName = json_encode($area->getName());
+            echo "[{$area->getId()}, {$areaName}],";
+        }
+        ?>
+    ]});
 
     function areas(val){
 


### PR DESCRIPTION
We need to use json_encode to properly escape user-entered names in generated JS code, which might contain special characters.

This is the same problem we fixed already for other pages. I hadn't realized it affected the project evaluation report too, which we use less often.

Fixes #564.