### PR TITLE
Copy result of legacy CSV exporter to clipboard.

### DIFF
--- a/web/js/include/ExportableGridPanel.js
+++ b/web/js/include/ExportableGridPanel.js
@@ -59,18 +59,15 @@ Ext.ux.ExportableGridPanel = Ext.extend(Ext.grid.GridPanel, {
 
     initComponent: function () {
         Ext.apply(this, {
-            bbar: [
-                {
-                    xtype: 'button',
-                    text: 'Download as CSV',
-                    handler: function () {
-                        //FIXME there must be a better way to get the grid
-                        var gridComponent = this.ownerCt.ownerCt;
-                        window.open("data:text/plain," + encodeURI(
-                                fromStoreToCSV(gridComponent.getStore(), gridComponent.getColumnModel())));
-                    }
-                },
-            ],
+            bbar: [{
+                xtype: 'button',
+                text: 'Copy to clipboard as CSV',
+                handler: function () {
+                    //FIXME there must be a better way to get the grid
+                    var gridComponent = this.ownerCt.ownerCt;
+                    navigator.clipboard.writeText(fromStoreToCSV(gridComponent.getStore(), gridComponent.getColumnModel()));
+                }
+            }],
         });
 
         /* call the superclass to preserve base class functionality */


### PR DESCRIPTION
Apparently, the data URLs generated by the legacy CSV exporter are not working in any browser.

Instead of trying to open a data URL, a quick workaround is to copy the contents of the CSV report to the clipboard. Users would be able to paste it into a text file, or even directly into a spreadsheet.

Copying to the clipboard appears to be more reliable than what we have now.