### PR TITLE
Fix Download as CSV button

### DIFF
--- a/web/js/include/ExportableGridPanel.js
+++ b/web/js/include/ExportableGridPanel.js
@@ -66,8 +66,12 @@ Ext.ux.ExportableGridPanel = Ext.extend(Ext.grid.GridPanel, {
                     handler: function () {
                         //FIXME there must be a better way to get the grid
                         var gridComponent = this.ownerCt.ownerCt;
-                        window.open("data:text/plain," + encodeURI(
-                                fromStoreToCSV(gridComponent.getStore(), gridComponent.getColumnModel())));
+                        const linkSource = `data:text/csv;charset=UTF-8,${encodeURIComponent(
+                            fromStoreToCSV(gridComponent.getStore(), gridComponent.getColumnModel()))}`;
+                        const downloadLink = document.createElement("a");
+                        downloadLink.href = linkSource;
+                        downloadLink.download = `${this.ownerCt.ownerCt.title.replace(/ /g, '')}.csv`;
+                        downloadLink.click();
                     }
                 },
             ],


### PR DESCRIPTION
Data URLs generated by the legacy CSV exporter wasn't working
anymore. The workarround to fix it is creating a temporary anchor
element, attach the data to it and simulate a click to download it.

Tested in Chrome, FF and Safari.