### PR TITLE
Deprecate VACATIONS_PROJECT config parameter

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -332,3 +332,10 @@ define('CALENDAR_URL', '');
 define('CALENDAR_ID', '');
 define('CALENDAR_USERNAME', '');
 define('CALENDAR_PASSWORD', '');
+
+/**
+ * Id of the project used for identifying vacations tasks.
+ * Replaces VACATIONS_PROJECT.
+ * @global int vacations project id.
+ */
+define('VACATIONS_PROJECT_ID', 1);

--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -506,6 +506,13 @@ class PostgreSQLTaskDAO extends TaskDAO{
     private ?int $vacationsProjectId = null;
 
     private function getVacationsProjectId() {
+        try {
+            return ConfigurationParametersManager::getParameter('VACATIONS_PROJECT_ID');
+        }
+        catch (UnknownParameterException $e) {
+            error_log("The VACATIONS_PROJECT configuration parameter will be deprecated. Use VACATIONS_PROJECT_ID instead.");
+        }
+
         if (!is_null($this->vacationsProjectId)) {
             return $this->vacationsProjectId;
         }

--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -503,9 +503,21 @@ class PostgreSQLTaskDAO extends TaskDAO{
         return $rows;
     }
 
+    /**
+     * This variable caches the result produced by getVacationsProjectId().
+     * @see getVacationsProjectId().
+     */
     private ?int $vacationsProjectId = null;
 
-    private function getVacationsProjectId() {
+    /** Retrieve the id for the configured VACATIONS_PROJECT.
+     *
+     * The project id will be retrieved based on the configuration parameters
+     * VACATIONS_PROJECT_ID or VACATIONS_PROJECT, in that order. The latter is
+     * considered deprecated and will log a warning.
+     * @return int The ID of the configured VACATIONS_PROJECT or null, if it's
+     * not properly set up.
+     */
+    public function getVacationsProjectId(): ?int {
         try {
             return ConfigurationParametersManager::getParameter('VACATIONS_PROJECT_ID');
         }

--- a/model/dao/TaskDAO/TaskDAO.php
+++ b/model/dao/TaskDAO/TaskDAO.php
@@ -301,4 +301,13 @@ abstract class TaskDAO extends BaseDAO{
      */
     public abstract function getLastTaskDate($userId, DateTime $referenceDate);
 
+    /** Retrieve the id for the configured VACATIONS_PROJECT.
+     *
+     * The project id will be retrieved based on the configuration parameters
+     * VACATIONS_PROJECT_ID and VACATIONS_PROJECT, in that order. The latter is
+     * considered deprecated and will log a warning.
+     * @return int The ID of the configured VACATIONS_PROJECT or null, if it's
+     * not properly set up.
+     */
+    public abstract function getVacationsProjectId(): ?int;
 }

--- a/model/facade/TasksFacade.php
+++ b/model/facade/TasksFacade.php
@@ -530,6 +530,21 @@ abstract class TasksFacade {
         return $dao->getLastTaskDate($userVO->getId(), $referenceDate);
     }
 
+    /** Retrieve the id for the configured VACATIONS_PROJECT.
+     *
+     * The project id will be retrieved based on the configuration parameters
+     * VACATIONS_PROJECT_ID and VACATIONS_PROJECT, in that order. The latter is
+     * considered deprecated and will log a warning.
+     * @return int The ID of the configured VACATIONS_PROJECT or null, if it's
+     * not properly set up.
+     */
+    static function GetVacationsProjectId(): ?int {
+        //There is no action object for this task:
+        //creating one action per facade method is an overkill if there
+        //are no plugins for that action; will be created only if needed.
+        $dao = DAOFactory::getTaskDAO();
+        return $dao->getVacationsProjectId();
+    }
 }
 
 //var_dump(TasksFacade::GetPersonalSummaryByUserIdDate(60, new DateTime()));

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -309,8 +309,7 @@ class HolidayService
             date_create($end),
             $userVO
         ));
-        $holidayProjectId = \ProjectsFacade::GetProjectByDescription(\ConfigurationParametersManager::getParameter('VACATIONS_PROJECT'));
-
+        $holidayProjectId = \TasksFacade::GetVacationsProjectId();
         $daysToDelete = array_diff($existingVacations, $vacations);
         $resultDeleted = $this->deleteVacations($daysToDelete, $userVO, $holidayProjectId);
 

--- a/web/tasks.php
+++ b/web/tasks.php
@@ -28,14 +28,7 @@ include_once(PHPREPORT_ROOT . '/model/facade/ProjectsFacade.php');
 
 include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
 
-$VACATIONS_PROJECT = ConfigurationParametersManager::getParameter('VACATIONS_PROJECT');
-
-$projects = ProjectsFacade::GetAllProjects();
-foreach((array) $projects as $project) {
-    if($project->getDescription() == $VACATIONS_PROJECT) {
-        $VACATIONS_PROJECT_ID = $project->getId();
-    }
-}
+$VACATIONS_PROJECT_ID = TasksFacade::GetVacationsProjectId();
 
 $user = $_SESSION['user'];
 


### PR DESCRIPTION
Create a new parameter, VACATIONS_PROJECT_ID, and add a migration path where the old parameter will still work if the new is not set.