### PR TITLE
Properly minify holidayManagement.js.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ help:
 
 minify:
 	# WARNING: this will remove any unstaged changes! Do not run on a development directory
-	for i in `find -name "*.min.js" -not -path "*web/vuejs/*"`; do rm $$i; done
-	for i in `find -name "*.min.js.map" -not -path "*web/vuejs/*"`; do rm $$i; done
+	for i in `find web -name "*.min.js" -not -path "*web/vuejs/*"`; do rm $$i; done
+	for i in `find web -name "*.min.js.map" -not -path "*web/vuejs/*"`; do rm $$i; done
 	#revert any previous minification changes
 	git reset --hard HEAD
-	for i in `find -name "*.js" -not -path "*web/vuejs/*" -not -path "*vendor*"` ; do \
+	for i in `find web -name "*.js" -not -path "*web/vuejs/*"` ; do \
 	  #extract file name to be used in the uglify output \
 	  FILE=`basename -s .js $$i`; \
 	  DIR=`dirname $$i`; \

--- a/web/holidayManagement.php
+++ b/web/holidayManagement.php
@@ -114,7 +114,7 @@ include_once("include/header.php");
     </div>
 </div>
 
-<script src='js/holidayManagement.js'></script>
+<script src="js/holidayManagement.js"></script>
 
 <?php
 include("include/footer.php");


### PR DESCRIPTION
This was not being minified because the regexp didn't match.

We also tune a bit the `find` commands, to reduce the search scope.