### PR TITLE
Workaround for minification error in tasks page.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ minify:
 	  HASH=`md5sum $$i | awk '{ print $$1 }'`; \
 	  cd $$DIR; \
 	  uglifyjs $${FILE}.js --output $${FILE}.$${HASH}.min.js \
-	      --source-map "filename='$${FILE}.$${HASH}.min.js.map'" -c -m; \
+	      --source-map "filename='$${FILE}.$${HASH}.min.js.map'" -m; \
 	  cd -; \
 	  for j in `find web -name "*.php"`; do \
 	    #modify script tags to link the minified file \

--- a/docs/developer/devel-setup.rst
+++ b/docs/developer/devel-setup.rst
@@ -19,6 +19,8 @@ generate minified versions of the JS code and the documentation pages:
 * Fedora: packages ``uglify-js`` and ``python3-docutils``.
 * Debian/Ubuntu: packages ``uglifyjs`` and ``python3-docutils``.
 
+NOTICE: UglifyJS version must be 3.15 or above.
+
 Step 1: Setting up the database
 ===============================
 
@@ -29,7 +31,7 @@ Step 2: Setting up the files
 ============================
 
 Clone the PhpReport repository ``https://github.com/Igalia/phpreport`` in a
-location available to the web server. The usual default location for the 
+location available to the web server. The usual default location for the
 Apache web server is: ``/var/www/html/``
 
 Alternatively, clone it elsewhere and create a link from the web server


### PR DESCRIPTION
Disable `-c` parameter in UglifyJS to prevent the error. This increases the output size, but only slightly (from ~700 KB to ~800 in tasks page).

Also write down the minimum UglifyJS version number known to prevent problems with the most modern JS syntax features.

Fixes #585.