### PR TITLE
Add updated_at field to task

### DIFF
--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -69,29 +69,28 @@ class PostgreSQLTaskDAO extends TaskDAO{
      */
     protected function setValues($row)
     {
+        $taskVO = new TaskVO();
 
-    $taskVO = new TaskVO();
+        $taskVO->setId($row['id']);
+        $taskVO->setDate(date_create($row['_date']));
+        $taskVO->setInit($row['init']);
+        $taskVO->setEnd($row['_end']);
+        $taskVO->setStory($row['story']);
+        if (strtolower($row['telework']) == "t")
+            $taskVO->setTelework(True);
+        elseif (strtolower($row['telework']) == "f")
+            $taskVO->setTelework(False);
+        if (strtolower($row['onsite']) == "t")
+            $taskVO->setOnsite(True);
+        elseif (strtolower($row['onsite']) == "f")
+            $taskVO->setOnsite(False);
+        $taskVO->setText($row['text']);
+        $taskVO->setTtype($row['ttype']);
+        $taskVO->setPhase($row['phase']);
+        $taskVO->setUserId($row['usrid']);
+        $taskVO->setProjectId($row['projectid']);
 
-    $taskVO->setId($row['id']);
-    $taskVO->setDate(date_create($row['_date']));
-    $taskVO->setInit($row['init']);
-    $taskVO->setEnd($row['_end']);
-    $taskVO->setStory($row['story']);
-    if (strtolower($row['telework']) == "t")
-        $taskVO->setTelework(True);
-    elseif (strtolower($row['telework']) == "f")
-        $taskVO->setTelework(False);
-    if (strtolower($row['onsite']) == "t")
-        $taskVO->setOnsite(True);
-    elseif (strtolower($row['onsite']) == "f")
-        $taskVO->setOnsite(False);
-    $taskVO->setText($row['text']);
-    $taskVO->setTtype($row['ttype']);
-    $taskVO->setPhase($row['phase']);
-    $taskVO->setUserId($row['usrid']);
-    $taskVO->setProjectId($row['projectid']);
-
-    return $taskVO;
+        return $taskVO;
     }
 
     /** Task retriever by id for PostgreSQL.

--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -89,6 +89,7 @@ class PostgreSQLTaskDAO extends TaskDAO{
         $taskVO->setPhase($row['phase']);
         $taskVO->setUserId($row['usrid']);
         $taskVO->setProjectId($row['projectid']);
+        $taskVO->setUpdatedAt($row['updated_at']);
 
         return $taskVO;
     }
@@ -699,7 +700,7 @@ class PostgreSQLTaskDAO extends TaskDAO{
         if ($last == (strlen($sql) - 2))
         $sql = substr($sql, 0, -2);
 
-        $sql = $sql . " WHERE id=".$taskVO->getId();
+        $sql = $sql . ", updated_at=now() WHERE id=".$taskVO->getId();
 
             $res = pg_query($this->connect, $sql);
         if ($res == NULL) throw new SQLQueryErrorException(pg_last_error());
@@ -899,7 +900,20 @@ class PostgreSQLTaskDAO extends TaskDAO{
     public function create(TaskVO $taskVO) {
         $affectedRows = 0;
 
-        $sql = "INSERT INTO task (_date, init, _end, story, telework, onsite, text, ttype, phase, usrid, projectid) VALUES(" .
+        $sql = "INSERT INTO task (" .
+            "_date, " .
+            "init, " .
+            "_end, " .
+            "story, " .
+            "telework, " .
+            "onsite, " .
+            "text, " .
+            "ttype, " .
+            "phase, " .
+            "usrid, " .
+            "projectid, " .
+            "updated_at " .
+            ") VALUES(" .
             DBPostgres::formatDate($taskVO->getDate()) . ", " .
             DBPostgres::checkNull($taskVO->getInit()) . ", " .
             DBPostgres::checkNull($taskVO->getEnd()) . ", " .
@@ -910,7 +924,9 @@ class PostgreSQLTaskDAO extends TaskDAO{
             DBPostgres::checkStringNull($taskVO->getTtype()) . ", " .
             DBPostgres::checkStringNull($taskVO->getPhase()) . ", " .
             DBPostgres::checkNull($taskVO->getUserId()) . ", " .
-            DBPostgres::checkNull($taskVO->getProjectId()) . ")";
+            DBPostgres::checkNull($taskVO->getProjectId()) . ", " .
+            "now()" .
+            ")" ;
 
         $res = pg_query($this->connect, $sql);
 

--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -835,55 +835,6 @@ class PostgreSQLTaskDAO extends TaskDAO{
         return true;
     }
 
-    /** Task updater for PostgreSQL.
-     *
-     * This function updates the data of a Task by its {@link TaskVO}.
-     * WARNING: it doesn't check if task overlaps with other tasks, because that
-     * would be very expensive to do for every task. TaskDAO::batchCreate should
-     * be used for that purpose.
-     * TODO: consider making private or even removing.
-     *
-     * @param TaskVO $taskVO the {@link TaskVO} with the data we want to update on database.
-     * @return int the number of rows that have been affected (it should be 1).
-     * @throws {@link SQLQueryErrorException}, {@link SQLUniqueViolationException}
-     */
-    public function update(TaskVO $taskVO) {
-        $affectedRows = 0;
-
-        if($taskVO->getId() != "") {
-            $currTaskVO = $this->getById($taskVO->getId());
-        }
-
-        // If the query returned a row then update
-        if(sizeof($currTaskVO) > 0) {
-
-            $sql = "UPDATE task SET _date=" . DBPostgres::formatDate($taskVO->getDate()) .
-                   ", init=" . DBPostgres::checkNull($taskVO->getInit()) .
-                   ", _end=" . DBPostgres::checkNull($taskVO->getEnd()) .
-                   ", story=" . DBPostgres::checkStringNull($taskVO->getStory()) .
-                   ", telework=" . DBPostgres::boolToString($taskVO->getTelework()) .
-                   ", onsite=" . DBPostgres::boolToString($taskVO->getOnsite()) .
-                   ", text=" . DBPostgres::checkStringNull($taskVO->getText()) .
-                   ", ttype=" . DBPostgres::checkStringNull($taskVO->getTtype()) .
-                   ", phase=" . DBPostgres::checkStringNull($taskVO->getPhase()) .
-                   ", usrid=" . DBPostgres::checkNull($taskVO->getUserId()) .
-                   ", projectid=" . DBPostgres::checkNull($taskVO->getProjectId()) .
-                   " WHERE id=".$taskVO->getId();
-
-            $res = pg_query($this->connect, $sql);
-
-            if ($res == NULL)
-                if (strpos(pg_last_error(), "unique_task_usr_time"))
-                    throw new SQLUniqueViolationException(pg_last_error());
-                else throw new SQLQueryErrorException(pg_last_error());
-
-            $affectedRows = pg_affected_rows($res);
-
-        }
-
-        return $affectedRows;
-    }
-
     /** Task creator for PostgreSQL.
      *
      * This function creates a new row for a Task by its {@link TaskVO}.

--- a/model/dao/TaskDAO/TaskDAO.php
+++ b/model/dao/TaskDAO/TaskDAO.php
@@ -52,17 +52,6 @@ abstract class TaskDAO extends BaseDAO{
      */
     protected $groupFields = array("USER" => "usrid", "PROJECT" => "projectid", "CUSTOMER" => "customerid", "TTYPE" => "ttype", "STORY" => "story");
 
-    /** Task DAO constructor.
-     *
-     * This is the base constructor of Task DAOs, and it just calls its parent's constructor.
-     *
-     * @throws {@link ConnectionErrorException}
-     * @see BaseDAO::__construct()
-     */
-    protected function __construct() {
-    parent::__construct();
-    }
-
     /** Task retriever by id.
      *
      * This function retrieves the row from Task table with the id <var>$taskId</var> and creates a {@link TaskVO} with its data.
@@ -249,16 +238,6 @@ abstract class TaskDAO extends BaseDAO{
      *         equal to the size of $tasks).
      */
     public abstract function batchPartialUpdate($tasks);
-
-    /** Task updater.
-     *
-     * This function updates the data of a Task by its {@link TaskVO}.
-     *
-     * @param TaskVO $taskVO the {@link TaskVO} with the data we want to update on database.
-     * @return int the number of rows that have been affected (it should be 1).
-     * @throws {@link OperationErrorException}, {@link SQLUniqueViolationException}
-     */
-    public abstract function update(TaskVO $taskVO);
 
     /** Task creator.
      *

--- a/model/vo/TaskVO.php
+++ b/model/vo/TaskVO.php
@@ -68,9 +68,9 @@ class TaskVO {
     protected $projectId = NULL;
 
     public function setId($id) {
-    if (is_null($id))
-        $this->id = $id;
-    else
+        if (is_null($id))
+            $this->id = $id;
+        else
             $this->id = (int) $id;
     }
 
@@ -87,9 +87,9 @@ class TaskVO {
     }
 
     public function setInit($init) {
-    if (is_null($init))
-        $this->init = $init;
-    else
+        if (is_null($init))
+            $this->init = $init;
+        else
             $this->init = (int) $init;
     }
 
@@ -98,9 +98,9 @@ class TaskVO {
     }
 
     public function setEnd($_end) {
-    if (is_null($_end))
-        $this->_end = $_end;
-    else
+        if (is_null($_end))
+            $this->_end = $_end;
+        else
             $this->_end = (int) $_end;
     }
 
@@ -158,8 +158,8 @@ class TaskVO {
 
     public function setUserId($userId) {
         if (is_null($userId))
-        $this->userId = $userId;
-    else
+            $this->userId = $userId;
+        else
             $this->userId = (int) $userId;
     }
 
@@ -169,8 +169,8 @@ class TaskVO {
 
     public function setProjectId($projectId) {
         if (is_null($projectId))
-        $this->projectId = $projectId;
-    else
+            $this->projectId = $projectId;
+        else
             $this->projectId = (int) $projectId;
     }
 

--- a/model/vo/TaskVO.php
+++ b/model/vo/TaskVO.php
@@ -66,6 +66,7 @@ class TaskVO {
     protected $phase = NULL;
     protected $userId = NULL;
     protected $projectId = NULL;
+    protected $updated_at = NULL;
 
     public function setId($id) {
         if (is_null($id))
@@ -176,6 +177,14 @@ class TaskVO {
 
     public function getProjectId() {
         return $this->projectId;
+    }
+
+    public function setUpdatedAt($updated_at) {
+        $this->updated_at = $updated_at ? new DateTime($updated_at) : NULL;
+    }
+
+    public function getUpdatedAt() {
+        return $this->updated_at;
     }
 
     /**#@-*/

--- a/sql/update/add-updated-at-to-task.sql
+++ b/sql/update/add-updated-at-to-task.sql
@@ -1,0 +1,5 @@
+--
+-- Add updated_at to task table so we can track when a task (specially leave tasks) was updated.
+--
+ALTER TABLE task
+ADD COLUMN updated_at timestamp;

--- a/sql/update/all.sql
+++ b/sql/update/all.sql
@@ -210,3 +210,16 @@ ADD COLUMN end_time integer;
 --
 
 UPDATE config SET version='2.21';
+
+
+--
+-- Add updated_at to task table so we can track when a task (specially leave tasks) was updated.
+--
+ALTER TABLE task
+ADD COLUMN updated_at timestamp;
+
+--
+-- Set database version to 2.22
+--
+
+UPDATE config SET version='2.22';

--- a/sql/update/bump-db-version-2-22.sql
+++ b/sql/update/bump-db-version-2-22.sql
@@ -1,0 +1,5 @@
+--
+-- Set database version to 2.22
+--
+
+UPDATE config SET version='2.22';

--- a/update/update-from-2.21-to-2.22.php
+++ b/update/update-from-2.21-to-2.22.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright (C) 2022 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+require_once('utils.php');
+
+define('PHPREPORT_ROOT', __DIR__ . '/../');
+define('SQLPATH', PHPREPORT_ROOT . 'sql/update/');
+
+/* These are the sql files that must be executed to prepare DB.
+ *
+ * IMPORTANT: they must be ordered for their proper execution.
+ */
+$sqlFiles = array();
+$sqlFiles[] = SQLPATH . "add-updated-at-to-task.sql";
+$sqlFiles[] = SQLPATH . "bump-db-version-2-22.sql";
+
+// run upgrade scripts
+
+require_once(PHPREPORT_ROOT . 'config/config.php');
+
+if (strcmp(get_db_version(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD), "2.21") != 0) {
+    print("Wrong database version. " .
+        "Make sure DB is on 2.21 version before running this upgrade.\n");
+    exit();
+}
+
+$success = true;
+foreach ($sqlFiles as $file) {
+    if (!parse_psql_dump($file, DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD)) {
+        $success = false;
+        break;
+    }
+}
+
+// finish, print message
+
+if ($success) {
+    print("Database update completed successfully\n");
+} else {
+    print("Error updating database in step: " . $file .
+        "\nPlease consider doing a manual update\n");
+}


### PR DESCRIPTION
We need to know when users update their tasks, specially the ones related to their vacation plans.

This patch adds a column called `updated_at` to the task table as well as their migration scripts.

It also starts populating the field whenever a task is created or updated.