### PR TITLE
Create vacation events as accepted by default in the calendar

### DIFF
--- a/model/facade/action/SyncCalendarAction.php
+++ b/model/facade/action/SyncCalendarAction.php
@@ -83,7 +83,7 @@ SUMMARY:' . $this->user->getLogin() . ' holiday
 DESCRIPTION:Event created automatically from PhpReport
 CLASS:PUBLIC
 X-SOGO-SEND-APPOINTMENT-NOTIFICATIONS:NO
-ATTENDEE;PARTSTAT=TENTATIVE;CN=' . $this->user->getLogin() . ';RSVP=TRUE;ROLE=REQ-PARTICIPANT:mailto:' . $userEmail . '
+ATTENDEE;PARTSTAT=ACCEPTED;CN=' . $this->user->getLogin() . ';RSVP=TRUE;ROLE=REQ-PARTICIPANT:mailto:' . $userEmail . '
 TRANSP:OPAQUE
 DTSTART;VALUE=DATE:' . $start . '
 DTEND;VALUE=DATE:' . $end . '


### PR DESCRIPTION
The events were being created as "not yet accepted" leading people to think they needed to accept the events. This patch changes the events to automatically accepted so people don't need to accept the invitation in their calendars.
