### PR TITLE
Add endpoint to create long periods of leaves

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -119,7 +119,9 @@ $permissions = array(
         //system settings
         '/settings.php',
         //API test
-        '/APITest.php'
+        '/APITest.php',
+        //Vacations management
+        '/services/updateLongLeaves.php',
     )
 );
 

--- a/docs/user/users-management.rst
+++ b/docs/user/users-management.rst
@@ -186,3 +186,22 @@ of the year, the end of the journey or the beginning of a future custom goal,
 whatever is closer in time. The extra hours value of the default goal is 0.
 For the most common cases, a default goals is equivalent to setting 1st Jan as
 init date, 31st Dec as end date and 0 as extra hours.
+
+Filling long periods of Sick Leaves
+===================================
+
+Sometimes a user needs to fill long periods of Sick Leave and from the Vacations
+Management interface this is not possible yet. The easiest way to accomplish this,
+is by using the `web/services/updateLongLeaves.php` endpoint, in which an admin
+user can pass the period, the user and for which project this should be filled.
+
+Expected query parameters:
+
+- `init`: date in the format `YYYY-MM-DD` for the day the period starts.
+- `end`: date in the format `YYYY-MM-DD` for the day the period ends.
+- `projectId`: the projectId for the Long leave.
+- `user`: the username for the user that will have the leaves filled.
+- `sid`: the session id of the admin that is making the request. This id can be
+retrieved by doing a GET request to `/phpreport/web/services/loginService.php`.
+
+Note that dates that fall on weekends won't be created.

--- a/tests/web/services/HolidayServiceTest.php
+++ b/tests/web/services/HolidayServiceTest.php
@@ -366,4 +366,14 @@ class HolidayServiceTest extends TestCase
             $this->instance->getWeeksFromYear(2024)
         );
     }
+
+    public function testGetDaysBetweenDates(): void
+    {
+        $expectedDates = ['2022-12-01', '2022-12-02', '2022-12-03', '2022-12-04', '2022-12-05'];
+
+        $this->assertSame(
+            $expectedDates,
+            $this->instance->getDaysBetweenDates('2022-12-01', '2022-12-05')
+        );
+    }
 }

--- a/util/LoginManager.php
+++ b/util/LoginManager.php
@@ -152,7 +152,7 @@ class LoginManager {
     /* We include the file with the array of permissions */
     require(PHPREPORT_ROOT . '/config/permissions.php');
 
-    if ($sid!=NULL)
+    if ($sid!=NULL && !isset($_SESSION))
       session_id($sid);
 
     if (!isset($_SESSION))

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -50,22 +50,22 @@ class HolidayService
      *
      * It receives an array of dates in the ISO format YYYY-MM-DD
      * and group them into date ranges if they are close by 1 day.
-     * 
+     *
      * Single dates are converted into a range with the same start
      * and end.
-     * 
+     *
      * Examples:
-     * 
+     *
      * 1. the array ['2021-01-01', '2021-01-02'] should return a
      * single range of dates that starts in 2021-01-01 and ends in
-     * 2021-01-02: 
+     * 2021-01-02:
      * [
      *    [
      *        'start' => '2021-01-01',
      *        'end' => '2021-01-02'
      *    ]
      * ]
-     * 
+     *
      * 2. ['2021-01-01'] will be converted in a range with the same
      * start and end date:
      * [
@@ -99,7 +99,7 @@ class HolidayService
                 }
             } elseif ($i + 1 == count($vacations)) {
                 // If it's the last element and the interval is 1 or 0, it means it's a single
-                // element array, so we should create a range for it 
+                // element array, so we should create a range for it
                 $ranges[] = ['start' => $start, 'end' => $vacations[$i]];
             }
             $last_date = $vacations[$i];
@@ -338,6 +338,32 @@ class HolidayService
             "datesAndRanges" => $this->getUserVacationsRanges($init, $end),
             "resultCreation" => $resultCreation,
             "resultDeleted" => $resultDeleted
+        ];
+    }
+
+    public function updateLongLeaves(string $init, string $end, string $user, string $projectId): array
+    {
+        if (!$this->loginManager::isLogged()) {
+            return ['error' => 'User not logged in'];
+        }
+
+        if (!$this->loginManager::isAllowed()) {
+            return ['error' => 'Forbidden service for this User'];
+        }
+
+        if (!$init || !$end || !$user || !$projectId) {
+            return ['error' => 'Init and end dates, user and projectId are mandatory'];
+        }
+
+        $userVO = \UsersFacade::GetUserByLogin($user);
+
+        $dates = $this->getDaysBetweenDates($init, $end);
+
+        $result = $this->createVacations($dates, $userVO, $projectId);
+
+        return [
+            "created" => $result["created"],
+            "failed" => $result["failed"]
         ];
     }
 

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -209,6 +209,23 @@ class HolidayService
         return $dates;
     }
 
+    static function getDaysBetweenDates(string $init, string $end): array
+    {
+        $begin = new \DateTime($init);
+        $end = new \DateTime($end);
+        $end = $end->modify('+1 day');
+
+        $interval = new \DateInterval('P1D');
+        $daterange = new \DatePeriod($begin, $interval, $end);
+        $dates = [];
+
+        foreach ($daterange as $date) {
+            $dates[] = $date->format("Y-m-d");
+        }
+
+        return $dates;
+    }
+
     public function getUserVacationsRanges(string $init = NULL, string $end = NULL, $sid = NULL, $userLogin = NULL): array
     {
         if (!$this->loginManager::isLogged($sid)) {

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -34,11 +34,14 @@ require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
 class HolidayService
 {
     private \LoginManager $loginManager;
+    private string $sid;
 
     public function __construct(
-        \LoginManager $loginManager
+        \LoginManager $loginManager,
+        string $sid = ''
     ) {
         $this->loginManager = $loginManager;
+        $this->sid = $sid;
     }
 
     function isWeekend(string $date): bool
@@ -343,11 +346,11 @@ class HolidayService
 
     public function updateLongLeaves(string $init, string $end, string $user, string $projectId): array
     {
-        if (!$this->loginManager::isLogged()) {
+        if (!$this->loginManager::isLogged($this->sid)) {
             return ['error' => 'User not logged in'];
         }
 
-        if (!$this->loginManager::isAllowed()) {
+        if (!$this->loginManager::isAllowed($this->sid)) {
             return ['error' => 'Forbidden service for this User'];
         }
 

--- a/web/services/updateLongLeaves.php
+++ b/web/services/updateLongLeaves.php
@@ -33,6 +33,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     return;
 }
 
+$sid = $_GET['sid'] ?? NULL;
 $init = $_GET['init'] ?? '';
 $end = $_GET['end'] ?? '';
 $user = $_GET['user'] ?? '';
@@ -40,7 +41,7 @@ $projectId = $_GET['projectId'] ?? '';
 
 $loginManager = new \LoginManager();
 
-$holidayService = new HolidayService($loginManager);
+$holidayService = new HolidayService($loginManager, $sid);
 
 $response = $holidayService->updateLongLeaves($init, $end, $user, $projectId);
 

--- a/web/services/updateLongLeaves.php
+++ b/web/services/updateLongLeaves.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright (C) 2021 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phpreport\Web\services\HolidayService;
+
+define('PHPREPORT_ROOT', __DIR__ . '/../../');
+
+require_once(PHPREPORT_ROOT . "/vendor/autoload.php");
+require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
+
+header('Content-Type: application/json; charset=utf-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    return;
+}
+
+$init = $_GET['init'] ?? '';
+$end = $_GET['end'] ?? '';
+$user = $_GET['user'] ?? '';
+$projectId = $_GET['projectId'] ?? '';
+
+$loginManager = new \LoginManager();
+
+$holidayService = new HolidayService($loginManager);
+
+$response = $holidayService->updateLongLeaves($init, $end, $user, $projectId);
+
+if (array_key_exists('error', $response)) {
+    // user is logged out or doesn't have permission
+    http_response_code(403);
+}
+
+echo json_encode($response);


### PR DESCRIPTION
This endpoint allows us to easily create long periods of leaves for users (normally needed for users that take sick leaves).

It was built in a generic way, so when making the request we need to pass the projectId as a query parameter, this way it can be used for different types of long leaves.