### PR TITLE
Allow 0 hour tasks

### DIFF
--- a/model/facade/action/PartialUpdateTasksAction.php
+++ b/model/facade/action/PartialUpdateTasksAction.php
@@ -128,18 +128,26 @@ class PartialUpdateTasksAction extends Action{
                 unset($this->tasks[$i]);
             }
 
-            if ($task->isInitDirty()){
-                // Check if init was updated and endTime should be converted to 24:00
-                // (case it was a 0-hour task and it's not anymore)
+            if ($task->isInitDirty() & !$task->isEndDirty()) {
                 $currentEndTime = $oldTask->getEnd();
                 $newInitTime = $task->getInit();
+                // Check if init was updated and endTime should be converted to 24:00
+                // (in case it was a 0-hour task and it's not anymore)
                 if ($newInitTime > $currentEndTime && $currentEndTime === 0) {
                     $task->setEnd(1440);
                 }
 
                 // Check if init was updated and endTime should be converted to 0h
-                // (case it was a regular task and now it's a 0-hour task)
+                // (in case it was a regular task and now it's a 0-hour task)
                 if ($newInitTime === 0 && $currentEndTime == 1440) {
+                    $task->setEnd(0);
+                }
+            } elseif ($task->isEndDirty()) {
+                $currentInitTime = $oldTask->getInit();
+                $newEndTime = $task->getEnd();
+                // Check if end was updated and it should be converted to 0
+                // (in case it became a 0-hour task)
+                if ($currentInitTime === 0 && $newEndTime === 1440) {
                     $task->setEnd(0);
                 }
             }

--- a/model/facade/action/PartialUpdateTasksAction.php
+++ b/model/facade/action/PartialUpdateTasksAction.php
@@ -127,6 +127,22 @@ class PartialUpdateTasksAction extends Action{
                 $discardedTasks[] = $task;
                 unset($this->tasks[$i]);
             }
+
+            if ($task->isInitDirty()){
+                // Check if init was updated and endTime should be converted to 24:00
+                // (case it was a 0-hour task and it's not anymore)
+                $currentEndTime = $oldTask->getEnd();
+                $newInitTime = $task->getInit();
+                if ($newInitTime > $currentEndTime && $currentEndTime === 0) {
+                    $task->setEnd(1440);
+                }
+
+                // Check if init was updated and endTime should be converted to 0h
+                // (case it was a regular task and now it's a 0-hour task)
+                if ($newInitTime === 0 && $currentEndTime == 1440) {
+                    $task->setEnd(0);
+                }
+            }
         }
 
         if ($taskDao->batchPartialUpdate($this->tasks) < count($this->tasks)) {

--- a/web/include/validations.js
+++ b/web/include/validations.js
@@ -109,13 +109,13 @@ Ext.apply(Ext.form.VTypes, {
             var start = field.parent.initTimeField;
             var time2 = start.parseDate(start.getValue());
             if (time2)
-                if ((time <= time2) && (val != "00:00")) return false;
+                if ((time < time2) && (val != "00:00")) return false;
         }
         else if (field.initTimeField) {
             var end = field.parent.endTimeField;
             var time2 = end.parseDate(end.getValue());
             if (time2)
-                if ((time2 <= time) && (end.getValue() != "00:00")) return false;
+                if ((time2 < time) && (end.getValue() != "00:00")) return false;
         }
         return true;
     },

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -173,7 +173,7 @@ function updateTasksLength(taskPanel) {
         end = taskPanel.endTimeField.getRawValue().split(':');
         endHour = end[0];
         endMinute = end[1];
-        if ((endHour == 0) && (endMinute == 0))
+        if ((endHour == 0) && (endMinute == 0) && (JSON.stringify(init) != JSON.stringify(end)))
             endHour = 24;
         diffHour = endHour - initHour;
         diffMinute = endMinute - initMinute;

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -123,7 +123,9 @@
                                 {
                                     $endTime = $parser->value;
                                     $endTimeParse = date_parse_from_format($endTimeFormat, $endTime);
-                                    if (($endTimeParse['hour']==0)&&($endTimeParse['minute']==0)) $endTimeParse['hour']=24;
+                                    if (($endTimeParse['hour']==0) && ($endTimeParse['minute']==0) && ($initTime != 0)) {
+                                        $endTimeParse['hour'] = 24;
+                                    }
                                     $endTime = $endTimeParse['hour']*60 + $endTimeParse['minute'];
                                     $taskVO->setEnd($endTime);
                                     $parser->next();


### PR DESCRIPTION
Some users need to record 0-hour tasks to record when they work
or took the day off but don't want to affect the amount of worked hours.
