### PR TITLE
Add year filter in vacation summary

### DIFF
--- a/web/holidaySummary.php
+++ b/web/holidaySummary.php
@@ -52,6 +52,9 @@ include_once("include/header.php");
                 </div>
             </div>
         </div>
+        <div class="content">
+            <h1>Summary for {{year}}</h1>
+        </div>
         <table class="report">
             <thead slot="head">
                 <th>User</th>

--- a/web/holidaySummary.php
+++ b/web/holidaySummary.php
@@ -33,7 +33,6 @@ include_once("include/header.php");
 <link rel="stylesheet" type="text/css" href="include/report.css" />
 
 <script src="vuejs/vue.min.js"></script>
-<script src="vuejs/v-calendar.2.3.2.min.js"></script>
 
 <div id="holidaySummaryReport">
     <div v-if="isLoading" class="loaderContainer">

--- a/web/include/report.css
+++ b/web/include/report.css
@@ -1,3 +1,8 @@
+.content {
+    margin: 20px auto;
+    max-width: 90%;
+}
+
 .report {
     padding: 0;
     max-width: 90%;

--- a/web/js/holidaySummary.js
+++ b/web/js/holidaySummary.js
@@ -42,6 +42,7 @@ var app = new Vue({
             autocompleteIsActive: false,
             searchProject: "",
             activeProject: 0,
+            year: new Date().getFullYear()
         };
     },
     created() {
@@ -49,7 +50,8 @@ var app = new Vue({
     },
     computed: {
         downloadUrl() {
-            return `services/getHolidaySummary.php?format=csv&users=${Object.keys(this.displayData).join(",")}`;
+            let url = `services/getHolidaySummary.php?format=csv&users=${Object.keys(this.displayData).join(",")}`;
+            return this.year ? `${url}&year=${this.year}` : url;
         },
     },
     methods: {
@@ -78,7 +80,13 @@ var app = new Vue({
             this.allProjects = parsedProjects;
         },
         async fetchSummary() {
+            let params = new URLSearchParams(window.location.search);
+            let year = params.get('year');
             let url = 'services/getHolidaySummary.php';
+            if (year) {
+                url += `?year=${year}`;
+                this.year = year;
+            }
             const res = await fetch(url, {
                 method: 'GET',
                 mode: 'same-origin',


### PR DESCRIPTION
A very quick hack to allow users to see next year's summary, this patch allows filtering the report by passing the desired year in the url, for example: `/web/holidaySummary.php?year=2023`

Next step would be adding a component in the UI to allow them to do it more easily.