### PR TITLE
Add OperationResult class and begin handling sql errors more gracefully

### DIFF
--- a/model/OperationResult.php
+++ b/model/OperationResult.php
@@ -32,51 +32,52 @@
  *
  *  This is the object returned for all CRUD operations
  *
-  *  @property boolean $isSuccessful Whether the operation was successful or not
-  *  @property int $responseCode The http status code
-  *  @property int $errorNumber The php error number
-  *  @property string $message Error message that is passed up to front end. Can be php error or custom string.
+ *  @property boolean $isSuccessful Whether the operation was successful or not
+ *  @property int $responseCode The http status code
+ *  @property int $errorNumber The php error number
+ *  @property string $message Error message that is passed up to front end. Can be php error or custom string.
  */
-class OperationResult {
-	public $isSuccessful;
-	public $responseCode;
-	public $errorNumber;
-	public $message;
+class OperationResult
+{
+    private $isSuccessful;
+    private $responseCode;
+    private $errorNumber;
+    private $message;
 
-	function __construct($isSuccessful, $responseCode = null) {
-		$this->isSuccessful = $isSuccessful;
-		$this->responseCode = $responseCode;
-	}
+    function __construct($isSuccessful, $responseCode = null) {
+        $this->isSuccessful = $isSuccessful;
+        $this->responseCode = $responseCode;
+    }
 
-	public function getIsSuccessful(){
-		return $this->isSuccessful;
-	}
+    public function getIsSuccessful(){
+        return $this->isSuccessful;
+    }
 
-	public function setIsSuccessful($isSuccessful){
-		$this->isSuccessful = (boolean) $isSuccessful;
-	}
+    public function setIsSuccessful($isSuccessful){
+        $this->isSuccessful = (boolean) $isSuccessful;
+    }
 
-	public function getResponseCode(){
-		return $this->responseCode;
-	}
+    public function getResponseCode(){
+        return $this->responseCode;
+    }
 
-	public function setResponseCode($responseCode){
-		$this->responseCode = (int) $responseCode;
-	}
+    public function setResponseCode($responseCode){
+        $this->responseCode = (int) $responseCode;
+    }
 
-	public function getErrorNumber(){
-		return $this->errorNumber;
-	}
+    public function getErrorNumber(){
+        return $this->errorNumber;
+    }
 
-	public function setErrorNumber($errorNumber){
-		$this->errorNumber = (int) $errorNumber;
-	}
+    public function setErrorNumber($errorNumber){
+        $this->errorNumber = (int) $errorNumber;
+    }
 
-	public function getMessage(){
-		return $this->message;
-	}
+    public function getMessage(){
+        return $this->message;
+    }
 
-	public function setMessage($message){
-		$this->message = (string) $message;
-	}
+    public function setMessage($message){
+        $this->message = (string) $message;
+    }
 }

--- a/model/OperationResult.php
+++ b/model/OperationResult.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2009 Igalia, S.L. <info@igalia.com>
+ * Copyright (C) 2023 Igalia, S.L. <info@igalia.com>
  *
  * This file is part of PhpReport.
  *
@@ -33,7 +33,7 @@
  *  This is the object returned for all CRUD operations
  *
   *  @property boolean $isSuccessful Whether the operation was successful or not
-  *  @property int $responseCode The http status code 
+  *  @property int $responseCode The http status code
   *  @property int $errorNumber The php error number
   *  @property string $message Error message that is passed up to front end. Can be php error or custom string.
  */

--- a/model/OperationResult.php
+++ b/model/OperationResult.php
@@ -1,0 +1,82 @@
+<?php
+/*
+ * Copyright (C) 2009 Igalia, S.L. <info@igalia.com>
+ *
+ * This file is part of PhpReport.
+ *
+ * PhpReport is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * PhpReport is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PhpReport.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/** File for OperationResult
+ *
+ *  This file just contains {@link OperationResult}.
+ *
+ * @filesource
+ * @package PhpReport
+ * @author Danielle Mayabb <danielle@igalia.com>
+ */
+
+/** Result returned after CRUD operations
+ *
+ *  This is the object returned for all CRUD operations
+ *
+  *  @property boolean $isSuccessful Whether the operation was successful or not
+  *  @property int $responseCode The http status code 
+  *  @property int $errorNumber The php error number
+  *  @property string $message Error message that is passed up to front end. Can be php error or custom string.
+ */
+class OperationResult {
+	public $isSuccessful;
+	public $responseCode;
+	public $errorNumber;
+	public $message;
+
+	function __construct($isSuccessful, $responseCode = null) {
+		$this->isSuccessful = $isSuccessful;
+		$this->responseCode = $responseCode;
+	}
+
+	public function getIsSuccessful(){
+		return $this->isSuccessful;
+	}
+
+	public function setIsSuccessful($isSuccessful){
+		$this->isSuccessful = (boolean) $isSuccessful;
+	}
+
+	public function getResponseCode(){
+		return $this->responseCode;
+	}
+
+	public function setResponseCode($responseCode){
+		$this->responseCode = (int) $responseCode;
+	}
+
+	public function getErrorNumber(){
+		return $this->errorNumber;
+	}
+
+	public function setErrorNumber($errorNumber){
+		$this->errorNumber = (int) $errorNumber;
+	}
+
+	public function getMessage(){
+		return $this->message;
+	}
+
+	public function setMessage($message){
+		$this->message = (string) $message;
+	}
+}

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -595,13 +595,13 @@ class PostgreSQLProjectDAO extends ProjectDAO {
      * The internal id of <var>$projectVO</var> will be set after its creation.
      *
      * @param ProjectVO $projectVO the {@link ProjectVO} with the data we want to insert on database.
-     * @return OperationResult an operation result object with properties indicating success and message
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link SQLQueryErrorException}
      */
     public function create(ProjectVO $projectVO) {
         $result = new OperationResult(true);
 
-        $sql = "INSERT INTO project (activation, init, _end, invoice, est_hours, 
+        $sql = "INSERT INTO project (activation, init, _end, invoice, est_hours,
         areaid, customerid, type, description, moved_hours, sched_type) VALUES(
             :activation, :init, :end, :invoice, :est_hours,
         :areaid, :customerid, :type, :description, :moved_hours, :sched_type)";
@@ -609,8 +609,8 @@ class PostgreSQLProjectDAO extends ProjectDAO {
         try {
             $statement = $this->pdo->prepare($sql);
             $statement->bindValue(":activation", $projectVO->getActivation(), PDO::PARAM_BOOL);
-            $statement->bindValue(":init", $projectVO->getInit(), PDO::PARAM_STR);
-            $statement->bindValue(":end", $projectVO->getEnd(), PDO::PARAM_STR);
+            $statement->bindValue(":init", DBPostgres::formatDate($projectVO->getInit()), PDO::PARAM_STR);
+            $statement->bindValue(":end", DBPostgres::formatDate($projectVO->getEnd()), PDO::PARAM_STR);
             $statement->bindValue(":invoice", $projectVO->getInvoice(), PDO::PARAM_STR);
             $statement->bindValue(":est_hours", $projectVO->getEstHours(), PDO::PARAM_STR);
             $statement->bindValue(":areaid", $projectVO->getAreaId(), PDO::PARAM_INT);

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -599,7 +599,7 @@ class PostgreSQLProjectDAO extends ProjectDAO {
      * @throws {@link SQLQueryErrorException}
      */
     public function create(ProjectVO $projectVO) {
-        $result = new OperationResult(true);
+        $result = new OperationResult(false);
 
         $sql = "INSERT INTO project (activation, init, _end, invoice, est_hours,
         areaid, customerid, type, description, moved_hours, sched_type) VALUES(
@@ -626,6 +626,7 @@ class PostgreSQLProjectDAO extends ProjectDAO {
 
             $projectVO->setId($this->pdo->lastInsertId('project_id_seq'));
 
+            $result->setIsSuccessful(true);
             $result->setMessage('Project created successfully.');
             $result->setResponseCode(201);
         }

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -633,6 +633,7 @@ class PostgreSQLProjectDAO extends ProjectDAO {
             error_log('Project creation failed: ' . $errorMessage);
             $result->setErrorNumber($ex->getCode());
             $resultMessage = "Project creation failed: \n";
+
             if(strpos($errorMessage, "Foreign key violation")){
                 if(strpos($errorMessage, "customerid")){
                     $resultMessage .= "Customer not yet created. Please create customer first. \n";
@@ -641,6 +642,12 @@ class PostgreSQLProjectDAO extends ProjectDAO {
                     $resultMessage .= "Area not yet created. Please create area first.";
                 }
             }
+            else if (strpos($errorMessage, "Not null violation")){
+                if(strpos($errorMessage,"areaid")){
+                    $resultMessage .= "Area is null. Please add area.";
+                }
+            }
+
             $result->setMessage($resultMessage);
             $result->setIsSuccessful(false);
             $result->setResponseCode(500);

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -37,6 +37,7 @@ include_once(PHPREPORT_ROOT . '/model/vo/CustomProjectVO.php');
 include_once(PHPREPORT_ROOT . '/model/dao/ProjectDAO/ProjectDAO.php');
 include_once(PHPREPORT_ROOT . '/model/dao/ProjectUserDAO/PostgreSQLProjectUserDAO.php');
 include_once(PHPREPORT_ROOT . '/model/dao/TaskDAO/PostgreSQLTaskDAO.php');
+include_once(PHPREPORT_ROOT . '/model/OperationResult.php');
 
 /** DAO for Projects in PostgreSQL
  *
@@ -594,36 +595,58 @@ class PostgreSQLProjectDAO extends ProjectDAO {
      * The internal id of <var>$projectVO</var> will be set after its creation.
      *
      * @param ProjectVO $projectVO the {@link ProjectVO} with the data we want to insert on database.
-     * @return int the number of rows that have been affected (it should be 1).
+     * @return OperationResult an operation result object with properties indicating success and message
      * @throws {@link SQLQueryErrorException}
      */
     public function create(ProjectVO $projectVO) {
-        $affectedRows = 0;
+        $result = new OperationResult(true);
 
-        $sql = "INSERT INTO project (activation, init, _end, invoice, est_hours,
-                areaid, customerid, type, description, moved_hours, sched_type) VALUES(" .
-                DBPostgres::boolToString($projectVO->getActivation()) . ", " .
-                DBPostgres::formatDate($projectVO->getInit()) . ", " .
-                DBPostgres::formatDate($projectVO->getEnd()) . ", " .
-                DBPostgres::checkNull($projectVO->getInvoice()) . ", " .
-                DBPostgres::checkNull($projectVO->getEstHours()) . ", " .
-                DBPostgres::checkNull($projectVO->getAreaId()) . ", " .
-                DBPostgres::checkNull($projectVO->getCustomerId()) . ", " .
-                DBPostgres::checkStringNull($projectVO->getType()) . ", " .
-                DBPostgres::checkStringNull($projectVO->getDescription()) . ", " .
-                DBPostgres::checkNull($projectVO->getMovedHours()) . ", " .
-                DBPostgres::checkStringNull($projectVO->getSchedType()) .")";
+        $sql = "INSERT INTO project (activation, init, _end, invoice, est_hours, 
+        areaid, customerid, type, description, moved_hours, sched_type) VALUES(
+            :activation, :init, :end, :invoice, :est_hours,
+        :areaid, :customerid, :type, :description, :moved_hours, :sched_type)";
 
-        $res = pg_query($this->connect, $sql);
+        try {
+            $statement = $this->pdo->prepare($sql);
+            $statement->bindValue(":activation", $projectVO->getActivation(), PDO::PARAM_BOOL);
+            $statement->bindValue(":init", $projectVO->getInit(), PDO::PARAM_STR);
+            $statement->bindValue(":end", $projectVO->getEnd(), PDO::PARAM_STR);
+            $statement->bindValue(":invoice", $projectVO->getInvoice(), PDO::PARAM_STR);
+            $statement->bindValue(":est_hours", $projectVO->getEstHours(), PDO::PARAM_STR);
+            $statement->bindValue(":areaid", $projectVO->getAreaId(), PDO::PARAM_INT);
+            $statement->bindValue(":customerid", $projectVO->getCustomerId(), PDO::PARAM_INT);
+            $statement->bindValue(":type", $projectVO->getType(), PDO::PARAM_STR);
+            $statement->bindValue(":description", $projectVO->getDescription(), PDO::PARAM_STR);
+            $statement->bindValue(":moved_hours", $projectVO->getMovedHours(), PDO::PARAM_STR);
+            $statement->bindValue(":sched_type", $projectVO->getSchedType(), PDO::PARAM_STR);
+            $statement->execute();
 
-        if ($res == NULL) throw new SQLQueryErrorException(pg_last_error());
+            $projectVO->setId($this->pdo->lastInsertId('project_id_seq'));
 
-        $projectVO->setId(DBPostgres::getId($this->connect, "project_id_seq"));
+            $result->setMessage('Project created successfully.');
+            $result->setResponseCode(201);
+        }
+        catch (PDOException $ex) {
+            //make sure to log the error as a failure, but return the OperationResult object
+            //successfully so that front end can see error and fail gracefully
+            $errorMessage = $ex->getMessage();
+            error_log('Project creation failed: ' . $errorMessage);
+            $result->setErrorNumber($ex->getCode());
+            $resultMessage = "Project creation failed: \n";
+            if(strpos($errorMessage, "Foreign key violation")){
+                if(strpos($errorMessage, "customerid")){
+                    $resultMessage .= "Customer not yet created. Please create customer first. \n";
+                }
+                if(strpos($errorMessage,"areaid")){
+                    $resultMessage .= "Area not yet created. Please create area first.";
+                }
+            }
+            $result->setMessage($resultMessage);
+            $result->setIsSuccessful(false);
+            $result->setResponseCode(500);
+        }
 
-        $affectedRows = pg_affected_rows($res);
-
-        return $affectedRows;
-
+        return $result;
     }
 
     /** Project deleter for PostgreSQL.

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -606,11 +606,14 @@ class PostgreSQLProjectDAO extends ProjectDAO {
             :activation, :init, :end, :invoice, :est_hours,
         :areaid, :customerid, :type, :description, :moved_hours, :sched_type)";
 
+        $initDateFormatted = (is_null($projectVO->getInit())) ? null : DBPostgres::formatDate($projectVO->getInit());
+        $endDateFormatted = (is_null($projectVO->getEnd())) ? null : DBPostgres::formatDate($projectVO->getEnd());
+
         try {
             $statement = $this->pdo->prepare($sql);
             $statement->bindValue(":activation", $projectVO->getActivation(), PDO::PARAM_BOOL);
-            $statement->bindValue(":init", DBPostgres::formatDate($projectVO->getInit()), PDO::PARAM_STR);
-            $statement->bindValue(":end", DBPostgres::formatDate($projectVO->getEnd()), PDO::PARAM_STR);
+            $statement->bindValue(":init", $initDateFormatted, PDO::PARAM_STR);
+            $statement->bindValue(":end", $endDateFormatted, PDO::PARAM_STR);
             $statement->bindValue(":invoice", $projectVO->getInvoice(), PDO::PARAM_STR);
             $statement->bindValue(":est_hours", $projectVO->getEstHours(), PDO::PARAM_STR);
             $statement->bindValue(":areaid", $projectVO->getAreaId(), PDO::PARAM_INT);
@@ -644,8 +647,12 @@ class PostgreSQLProjectDAO extends ProjectDAO {
             }
             else if (strpos($errorMessage, "Not null violation")){
                 if(strpos($errorMessage,"areaid")){
-                    $resultMessage .= "Area is null. Please add area.";
+                    $resultMessage .= "Area is null. Please choose area.";
                 }
+            }
+            else {
+                //if not a predictable error like FK/null violation, just return the native error code and message
+                $resultMessage .= $result . $errorMessage;
             }
 
             $result->setMessage($resultMessage);

--- a/model/dao/ProjectDAO/ProjectDAO.php
+++ b/model/dao/ProjectDAO/ProjectDAO.php
@@ -210,7 +210,7 @@ abstract class ProjectDAO extends BaseDAO{
      * The internal id of <var>$projectVO</var> will be set after its creation.
      *
      * @param ProjectVO $projectVO the {@link ProjectVO} with the data we want to insert on database.
-     * @return int the number of rows that have been affected (it should be 1).
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link OperationErrorException}
      */
     public abstract function create(ProjectVO $projectVO);
@@ -220,7 +220,7 @@ abstract class ProjectDAO extends BaseDAO{
      * This function deletes the data of a Project by its {@link ProjectVO}.
      *
      * @param ProjectVO $projectVO the {@link ProjectVO} with the data we want to delete from database.
-     * @return int the number of rows that have been affected (it should be 1).
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link OperationErrorException}
      */
     public abstract function delete(ProjectVO $projectVO);

--- a/model/facade/ProjectsFacade.php
+++ b/model/facade/ProjectsFacade.php
@@ -130,7 +130,7 @@ abstract class ProjectsFacade {
      *  This function is used for creating a new Project.
      *
      * @param ProjectVO $project the Project value object we want to create.
-     * @return OperationResult it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link SQLQueryErrorException}
      */
     static function CreateProject(ProjectVO $project) {
@@ -147,7 +147,7 @@ abstract class ProjectsFacade {
      *  If an error occurs, it stops creating.
      *
      * @param array $projects the Project value objects we want to create.
-     * @return OperationResult it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link SQLQueryErrorException}
      */
     static function CreateProjects($projects) {

--- a/model/facade/ProjectsFacade.php
+++ b/model/facade/ProjectsFacade.php
@@ -147,13 +147,14 @@ abstract class ProjectsFacade {
      *  If an error occurs, it stops creating.
      *
      * @param array $projects the Project value objects we want to create.
-     * @return OperationResult the result {@link OperationResult} with information about operation status
+     * @return array OperationResult the araray of results {@link OperationResult} with information about operation status
      * @throws {@link SQLQueryErrorException}
      */
     static function CreateProjects($projects) {
-
+        $operationResults = [];
         foreach ((array) $projects as $project)
-            return ProjectsFacade::CreateProject($project);
+            $operationResults[] = ProjectsFacade::CreateProject($project);
+        return $operationResults;
     }
 
     /** Delete Project Function

--- a/model/facade/ProjectsFacade.php
+++ b/model/facade/ProjectsFacade.php
@@ -130,7 +130,7 @@ abstract class ProjectsFacade {
      *  This function is used for creating a new Project.
      *
      * @param ProjectVO $project the Project value object we want to create.
-     * @return int it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
+     * @return OperationResult it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
      * @throws {@link SQLQueryErrorException}
      */
     static function CreateProject(ProjectVO $project) {
@@ -147,17 +147,13 @@ abstract class ProjectsFacade {
      *  If an error occurs, it stops creating.
      *
      * @param array $projects the Project value objects we want to create.
-     * @return int it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
+     * @return OperationResult it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
      * @throws {@link SQLQueryErrorException}
      */
     static function CreateProjects($projects) {
 
-    foreach((array)$projects as $project)
-        if ((ProjectsFacade::CreateProject($project)) == -1)
-            return -1;
-
-    return 0;
-
+        foreach ((array) $projects as $project)
+            return ProjectsFacade::CreateProject($project);
     }
 
     /** Delete Project Function

--- a/model/facade/action/CreateProjectAction.php
+++ b/model/facade/action/CreateProjectAction.php
@@ -32,6 +32,7 @@
 include_once(PHPREPORT_ROOT . '/model/facade/action/Action.php');
 include_once(PHPREPORT_ROOT . '/model/dao/DAOFactory.php');
 include_once(PHPREPORT_ROOT . '/model/vo/ProjectVO.php');
+include_once(PHPREPORT_ROOT . '/model/OperationResult.php');
 
 /** Create Project Action
  *
@@ -68,19 +69,13 @@ class CreateProjectAction extends Action{
      *
      * This is the function that contains the code that creates the new Project, storing it persistently.
      *
-     * @return int it just indicates if there was any error (<i>-1</i>) or not (<i>0</i>).
+     * @return OperationResult the result {@link OperationResult} with information about operation status
      * @throws {@link SQLQueryErrorException}
      */
     protected function doExecute() {
-
-    $dao = DAOFactory::getProjectDAO();
-        if ($dao->create($this->project)!=1) {
-            return -1;
-        }
-
-        return 0;
+        $dao = DAOFactory::getProjectDAO();
+        return $dao->create($this->project);
     }
-
 }
 
 

--- a/web/js/projectManagement.js
+++ b/web/js/projectManagement.js
@@ -1106,7 +1106,7 @@ Ext.onReady(function(){
                 projectGrid.getSelectionModel().selectRow(rowIndex);
                 projectGrid.getView().focusRow(rowIndex);
             },
-            'exception': function(proxy, type, action, exception, res){
+            'exception': function(proxy, type, action, eOpts, res){
                 let parser = new DOMParser();
                 let errorDoc = parser.parseFromString(res.responseText, "text/xml");
                 let errorMessage = errorDoc.getElementsByTagName("error")[0].childNodes[0].nodeValue;

--- a/web/js/projectManagement.js
+++ b/web/js/projectManagement.js
@@ -1100,21 +1100,21 @@ Ext.onReady(function(){
         listeners: {
             'write': function (store, action, result, res, rs) {
                 App.setAlert(true, "Projects Changes Saved");
-                
+
                 // select newly added row and scroll to it
                 var rowIndex = store.indexOf(rs);
                 projectGrid.getSelectionModel().selectRow(rowIndex);
                 projectGrid.getView().focusRow(rowIndex);
             },
             'exception': function(proxy, type, action, exception, res){
-                var parser = new DOMParser();
-                var errorDoc = parser.parseFromString(res.responseText, "text/xml");
-                var errorMessage = errorDoc.getElementsByTagName("error")[0].childNodes[0].nodeValue;
+                let parser = new DOMParser();
+                let errorDoc = parser.parseFromString(res.responseText, "text/xml");
+                let errorMessage = errorDoc.getElementsByTagName("error")[0].childNodes[0].nodeValue;
                 App.setAlert(false, errorMessage);
             }
         }
     });
-   
+
 
     var projectColModel =  new Ext.grid.ColumnModel([
         {

--- a/web/js/projectManagement.js
+++ b/web/js/projectManagement.js
@@ -1111,6 +1111,8 @@ Ext.onReady(function(){
                 let errorDoc = parser.parseFromString(res.responseText, "text/xml");
                 let errorMessage = errorDoc.getElementsByTagName("error")[0].childNodes[0].nodeValue;
                 App.setAlert(false, errorMessage);
+                //if creation fails, reload data store so that "dirty" record from attempt doesn't persist
+                projectsStore.reload();
             }
         }
     });

--- a/web/js/projectManagement.js
+++ b/web/js/projectManagement.js
@@ -1100,18 +1100,21 @@ Ext.onReady(function(){
         listeners: {
             'write': function (store, action, result, res, rs) {
                 App.setAlert(true, "Projects Changes Saved");
-
+                
                 // select newly added row and scroll to it
                 var rowIndex = store.indexOf(rs);
                 projectGrid.getSelectionModel().selectRow(rowIndex);
                 projectGrid.getView().focusRow(rowIndex);
             },
-            'exception': function(){
-                App.setAlert(false, "Some Error Occurred While Saving The Changes");
-            },
+            'exception': function(proxy, type, action, exception, res){
+                var parser = new DOMParser();
+                var errorDoc = parser.parseFromString(res.responseText, "text/xml");
+                var errorMessage = errorDoc.getElementsByTagName("error")[0].childNodes[0].nodeValue;
+                App.setAlert(false, errorMessage);
+            }
         }
     });
-
+   
 
     var projectColModel =  new Ext.grid.ColumnModel([
         {

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -211,23 +211,24 @@
     if (count($createProjects) >= 1)
         if(count($createProjects) == 1){
             $operationResult = ProjectsFacade::CreateProject($createProjects[0]);
-            if ($operationResult->isSuccessful == false){
-                http_response_code(500);
-                $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
+            if (!$operationResult->getIsSuccessful()) {
+                http_response_code($operationResult->getResponseCode());
+                $string = "<return service='createProjects'><error id='" . $operationResult->getErrorNumber() . "'>" . $operationResult->getMessage() . "</error></return>";
             }
         }
         else {
             //leaving the possibility to create multiple projects in the future
             $operationResults = ProjectsFacade::CreateProjects($createProjects);
             $errors = array_filter($operationResults, function ($item) {
-                return ($item->isSuccessful == false);
+                return (!$item->getIsSuccessful());
             });
             if($errors){
+                //if multiple failures, let's just return a 500
                 http_response_code(500);
                 $string .= "<return service='createProjects'><errors>";
                     foreach((array) $errors as $result){
-                        if (!$result->isSuccessful)
-                            $string .= "<error id=''>" . $result->message . "</error>";
+                        if (!$result->getIsSuccessful())
+                            $string .= "<error id=''>" . $result->getMessage() . "</error>";
                     }
                 $string .= "</errors></return>";
             }

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -211,28 +211,26 @@
     if (count($createProjects) >= 1)
         if(count($createProjects) == 1){
             $operationResult = ProjectsFacade::CreateProject($createProjects[0]);
-            if (!$operationResult->isSuccessful)
+            if ($operationResult->isSuccessful == false){
                 http_response_code(500);
                 $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
+            }
         }
         else {
             //leaving the possibility to create multiple projects in the future
             $operationResults = ProjectsFacade::CreateProjects($createProjects);
-            $string = "<return service='createProjects'>";
             $errors = array_filter($operationResults, function ($item) {
                 return ($item->isSuccessful == false);
             });
             if($errors){
                 http_response_code(500);
-                $string .= "<errors>";
+                $string .= "<return service='createProjects'><errors>";
                     foreach((array) $errors as $result){
                         if (!$result->isSuccessful)
                             $string .= "<error id=''>" . $result->message . "</error>";
                     }
-                $string .= "</errors>";
+                $string .= "</errors></return>";
             }
-
-            $string .= "</return>";
         }
 
 

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -212,6 +212,7 @@
         if(count($createProjects) == 1){
             $operationResult = ProjectsFacade::CreateProject($createProjects[0]);
             if (!$operationResult->isSuccessful)
+                http_response_code(500);
                 $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
         }
         else {
@@ -219,19 +220,16 @@
             $operationResults = ProjectsFacade::CreateProjects($createProjects);
             $string = "<return service='createProjects'>";
             $errors = array_filter($operationResults, function ($item) {
-                return ($item->isSuccessful = false);
+                return ($item->isSuccessful == false);
             });
             if($errors){
-            $string .= "<errors>";
-                foreach((array) $errors as $result){
-                    if (!$result->isSuccessful)
-                        $string .= "<error id=''>" . $result->message . "</error>";
-                }
-            $string .= "</errors>";
-
-            }
-            else {
-            $string .= "<ok>All operations successful</ok>";
+                http_response_code(500);
+                $string .= "<errors>";
+                    foreach((array) $errors as $result){
+                        if (!$result->isSuccessful)
+                            $string .= "<error id=''>" . $result->message . "</error>";
+                    }
+                $string .= "</errors>";
             }
 
             $string .= "</return>";

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -209,9 +209,34 @@
 
 
     if (count($createProjects) >= 1)
-        $operationResult = ProjectsFacade::CreateProjects($createProjects);
-        if (!$operationResult->isSuccessful)
-            $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
+        if(count($createProjects) == 1){
+            $operationResult = ProjectsFacade::CreateProject($createProjects[0]);
+            if (!$operationResult->isSuccessful)
+                $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
+        }
+        else {
+            //leaving the possibility to create multiple projects in the future
+            $operationResults = ProjectsFacade::CreateProjects($createProjects);
+            $string = "<return service='createProjects'>";
+            $errors = array_filter($operationResults, function ($item) {
+                return ($item->isSuccessful = false);
+            });
+            if($errors){
+            $string .= "<errors>";
+                foreach((array) $errors as $result){
+                    if (!$result->isSuccessful)
+                        $string .= "<error id=''>" . $result->message . "</error>";
+                }
+            $string .= "</errors>";
+
+            }
+            else {
+            $string .= "<ok>All operations successful</ok>";
+            }
+
+            $string .= "</return>";
+        }
+
 
 
     if (!isset($string))

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -30,6 +30,7 @@
     include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
     include_once(PHPREPORT_ROOT . '/model/facade/ProjectsFacade.php');
     include_once(PHPREPORT_ROOT . '/model/vo/ProjectVO.php');
+    include_once(PHPREPORT_ROOT . '/model/OperationResult.php');
 
     $parser = new XMLReader();
 
@@ -208,11 +209,12 @@
 
 
     if (count($createProjects) >= 1)
-        if (ProjectsFacade::CreateProjects($createProjects) == -1)
-            $string = "<return service='createProjects'><error id='1'>There was some error while creating the projects</error></return>";
+        $operationResult = ProjectsFacade::CreateProjects($createProjects);
+        if (!$operationResult->isSuccessful)
+            $string = "<return service='createProjects'><error id='1'>". $operationResult->message . "</error></return>";
 
 
-    if (!$string)
+    if (!isset($string))
     {
         $string = "<return service='createProjects'><ok>Operation Success!</ok><projects>";
 

--- a/web/services/createProjectsService.php
+++ b/web/services/createProjectsService.php
@@ -225,7 +225,7 @@
             if($errors){
                 //if multiple failures, let's just return a 500
                 http_response_code(500);
-                $string .= "<return service='createProjects'><errors>";
+                $string = "<return service='createProjects'><errors>";
                     foreach((array) $errors as $result){
                         if (!$result->getIsSuccessful())
                             $string .= "<error id=''>" . $result->getMessage() . "</error>";


### PR DESCRIPTION
This PR begins to address #496 by adding an OperationResult class and updates code related to the creation of Projects to begin using this class. Changes in these commits include:
- Add the OperationResult class
- Refactor Project DAO and Facade to use this class
- Update createProjectsService to check class
- Update projectManagement.js exception handler for project creation to pass along the message from the back end.

Comments and suggestions welcome as my PHP is a bit rusty.