### PR TITLE
611 midnight task error

### DIFF
--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -217,7 +217,6 @@
                 }
                 //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users
                 if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
-                    $endTimeParse = date_parse_from_format($endTimeFormat, $endTime);
                     $endTime = $endTimeParseOrig['hour']*60 + $endTimeParseOrig['minute'];
                     $taskVO->setEnd($endTime);
                 }

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -217,7 +217,7 @@
                 }
                 //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users
                 if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
-                    $endTime = $endTimeParseOrig['hour']*60 + $endTimeParseOrig['minute'];
+                    $endTime = 0;
                     $taskVO->setEnd($endTime);
                 }
 

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -122,8 +122,10 @@
                                 if ($parser->hasValue)
                                 {
                                     $endTime = $parser->value;
+                                    //set one version that we don't change here so that we can process vs init time after parse for 0-hour tasks
+                                    $endTimeParseOrig = date_parse_from_format($endTimeFormat, $endTime);
                                     $endTimeParse = date_parse_from_format($endTimeFormat, $endTime);
-                                    if (($endTimeParse['hour']==0) && ($endTimeParse['minute']==0) && ($initTime != 0)) {
+                                    if (($endTimeParse['hour']==0) && ($endTimeParse['minute']==0)) {
                                         $endTimeParse['hour'] = 24;
                                     }
                                     $endTime = $endTimeParse['hour']*60 + $endTimeParse['minute'];
@@ -212,6 +214,12 @@
                 {
                     $string = "<return service='createTasks'><success>false</success><error id='4'>projectId is not valid</error></return>";
                     break;
+                }
+                //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users
+                if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
+                    $endTimeParse = date_parse_from_format($endTimeFormat, $endTime);
+                    $endTime = $endTimeParseOrig['hour']*60 + $endTimeParseOrig['minute'];
+                    $taskVO->setEnd($endTime);
                 }
 
                 $createTasks[] = $taskVO;

--- a/web/services/updateTasksService.php
+++ b/web/services/updateTasksService.php
@@ -138,6 +138,8 @@
                                 {
                                     $endTime = $parser->value;
                                     $endTimeParse = date_parse_from_format($endTimeFormat, $endTime);
+                                    //set one version that we don't change here so that we can process vs init time after parse for 0-hour tasks
+                                    $endTimeParseOrig = date_parse_from_format($endTimeFormat, $endTime);
                                     if (($endTimeParse['hour']==0) && ($endTimeParse['minute']==0)) $endTimeParse['hour'] = 24;
                                     $endTime = $endTimeParse['hour']*60 + $endTimeParse['minute'];
                                     $taskVO->setEnd($endTime);
@@ -248,6 +250,12 @@
                 }
 
                 $taskVO->setUserId($user->getId());
+
+                //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users
+                if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
+                    $endTime = 0;
+                    $taskVO->setEnd($endTime);
+                }
 
                 $updateTasks[] = $taskVO;
 


### PR DESCRIPTION
Fixes #611 

I removed the check against `$initTime` out of the parser switch statement for the `$endTime` block since values are set in the order the user set them, which could cause errors due to variables/values not being set yet. I instead make the check after the switch block is done. 