### PR TITLE
Check for existence of variables before doing anything else

### DIFF
--- a/web/services/updateTasksService.php
+++ b/web/services/updateTasksService.php
@@ -252,9 +252,11 @@
                 $taskVO->setUserId($user->getId());
 
                 //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users
-                if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
-                    $endTime = 0;
-                    $taskVO->setEnd($endTime);
+                if(isset($endTimeParseOrig) && isset($initTime)){
+                    if (($endTimeParseOrig['hour']==0) && ($endTimeParseOrig['minute']==0) && ($initTime == 0)) {
+                        $endTime = 0;
+                        $taskVO->setEnd($endTime);
+                    }
                 }
 
                 $updateTasks[] = $taskVO;


### PR DESCRIPTION
In fixing #611, I inadvertantly created the same issue in the updateTasksService that was originally happening in the createTasksService - variables not initialized before code tries to check them. in this instance, if someone updates any property(ies) that are **not** the endTime or initTime, an error will be thrown. This is a simple check to first make sure we have the variables we need before doing further processing. 

I could do the check all in one statement instead of having the 2 "if" blocks, if it is preferred to be more concise. 