### PR TITLE
Error message for missing compulsory fields on task create.

### DIFF
--- a/model/dao/TaskDAO/PostgreSQLTaskDAO.php
+++ b/model/dao/TaskDAO/PostgreSQLTaskDAO.php
@@ -895,6 +895,13 @@ class PostgreSQLTaskDAO extends TaskDAO{
             if(strpos($errorMessage, "end_after_init_task")) {
                 $resultMessage .= "Start time later than end time.";
             }
+            else if(strpos($errorMessage, "Not null violation")) {
+                $resultMessage .= "Missing compulsory data";
+                if(!$taskVO->getInit() || !$taskVO->getEnd()) {
+                    $resultMessage .= ": init and/or end time";
+                }
+                $resultMessage .= ".";
+            }
             else {
                 $resultMessage .= $errorMessage;
             }


### PR DESCRIPTION
We check for "not null violation" error messages from PostgreSQL and turn them into a more user friendly message: "Missing compulsory data". We add a specific check and message for missing init and end time fields which are the only ones that realistically can happen at that point; missing project and user fields should have been checked in upper layers.

This fixes an old bug, #110, together with the recent work to turn SQL exceptions into error messages.