### PR TITLE
Increase autosave interval for tasks

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -992,7 +992,7 @@ Ext.onReady(function(){
         if(isUnsaved()) {
             saveTasks(false);
         }
-    }, 10000);
+    }, 30000);
 
     /* Build a calendar on the auxiliar sidebar */
     new Ext.Panel({


### PR DESCRIPTION
Some users are experiencing some friction/confusion when adding/editing tasks. Specifically, the "detected overlapping times" error alert will pop up intermittently even when task times do not overlap. It's hard to reproduce, but the best @anarute and I can figure is that there is dirty/incomplete data passed along during the auto-save that is possibly causing this error. 

This small code change - increasing the auto-save interval from 10s to 30s - would help in the short-term. Thirty seconds is still a short interval while being long enough to allow for a user to settle task times before the auto-save is engaged.