### PR TITLE
Add confirmation modal when deleting template

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1290,14 +1290,17 @@ Ext.onReady(function(){
                 text: 'Delete',
                 flex: 1,
                 handler: function () {
-                    //remove from the store
-                    store = Ext.StoreMgr.get('templatesStore')
-                    store.remove(store.getById(templateValues['id']));
-
-                    //remove from the panel
-                    var row = this.findParentByType('panel');
-                    var panel = row.findParentByType('panel');
-                    panel.remove(row);
+                    Ext.Msg.confirm("Confirmation", "Are you sure you want to delete this template?", function(btnText){
+                        if(btnText == "yes"){
+                            //remove from the store
+                            store = Ext.StoreMgr.get('templatesStore')
+                            store.remove(store.getById(templateValues['id']));
+                            //remove from the panel
+                            var row = this.findParentByType('panel');
+                            var panel = row.findParentByType('panel');
+                            panel.remove(row);
+                        }
+                    }, this)
                 },
             });
             this.add(new Ext.Panel({


### PR DESCRIPTION
It is very easy to accidentally delete a template. The code here puts a confirmation modal in place so that a user has an escape hatch if they accidentally click the 'delete' button for a template they actually want to keep.