### PR TITLE
Make sure not to send email to new joiners

### DIFF
--- a/jobs/sendEmailAlertNoFill.php
+++ b/jobs/sendEmailAlertNoFill.php
@@ -79,7 +79,10 @@
 
     foreach ($users as $user) {
         if (!in_array($user->getLogin(), $excludedUsers)) {
-            $period = UsersFacade::GetUserJourneyHistoriesByIntervals($today, $today, $user->getId());
+            $lastMonday = new DateTime(date("Y-m-d", strtotime("last week monday")));
+            $lastFriday = new DateTime(date("Y-m-d", strtotime("last week friday")));
+
+            $period = UsersFacade::GetUserJourneyHistoriesByIntervals($lastMonday, $lastMonday, $user->getId());
             if (empty($period) || ($period[0]->getJourney() == 0)) {
                 // User is not currently hired or is on leave of absence, skip it.
                 continue;
@@ -88,8 +91,6 @@
             $login = $user->getLogin();
             $email = $login . "@" . $COMPANY_DOMAIN;
             $from = $NO_FILL_EMAIL_FROM;
-            $lastMonday = new DateTime(date("Y-m-d", strtotime("last week monday")));
-            $lastFriday = new DateTime(date("Y-m-d", strtotime("last week friday")));
 
             $emptyDaysLastWeek = TasksFacade::getEmptyDaysInPeriod($user, $lastMonday, $lastFriday);
 

--- a/jobs/sendEmailSummaryNoFill.php
+++ b/jobs/sendEmailSummaryNoFill.php
@@ -61,7 +61,7 @@
 
     foreach ($users as $user) {
         if (! in_array($user->getLogin(), $excludedUsers)) {
-            $period = UsersFacade::GetUserJourneyHistoriesByIntervals($today, $today, $user->getId());
+            $period = UsersFacade::GetUserJourneyHistoriesByIntervals($monday3weeksAgo, $lastMonday, $user->getId());
             if (empty($period) || ($period[0]->getJourney() == 0)) {
                 // User is not currently hired or is on leave of absence, skip it.
                 continue;
@@ -71,13 +71,13 @@
             $emptyDaysLastWeek = TasksFacade::getEmptyDaysInPeriod($user, $lastMonday, $lastFriday);
             $emptyDays2WeeksAgo = TasksFacade::getEmptyDaysInPeriod($user, $monday2weeksAgo, $friday2weeksAgo);
             $emptyDays3WeeksAgo = TasksFacade::getEmptyDaysInPeriod($user, $monday3weeksAgo, $friday3weeksAgo);
-            if (!empty($emptyDaysLastWeek)) {
+            if (!empty($emptyDaysLastWeek) && ($period[0]->getInitDate() <= $lastMonday)) {
                 array_push($warnedUsers, $user->getLogin());
             }
-            if (!empty($emptyDays2WeeksAgo)) {
+            if (!empty($emptyDays2WeeksAgo) && ($period[0]->getInitDate() <= $monday2weeksAgo)) {
                 array_push($criticalUsers, $user->getLogin());
             }
-            if (!empty($emptyDays3WeeksAgo)) {
+            if (!empty($emptyDays3WeeksAgo) && ($period[0]->getInitDate() <= $monday3weeksAgo)) {
                 array_push($blockedUsers, $user->getLogin());
             }
         }


### PR DESCRIPTION
The script was checking if the user had a journey or not, so if a user joined the current week they would receive a reminder because they are active but haven't filled the past week.

This patch checks if the user joined at least a week ago and for the summary email, also checks if they were active in the previous weeks too before adding them to the lists.