### PR TITLE
Fix for Dockerfile smell DL3020

### DIFF
--- a/docker/dev.app.Dockerfile
+++ b/docker/dev.app.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 
 RUN apt-get -y install postgresql apache2 php php-pgsql php-xml supervisor make docutils-common uglifyjs git
 
-ADD . /var/www/html/phpreport/
+COPY . /var/www/html/phpreport/
 
 WORKDIR  /var/www/html/phpreport/
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/dev.app.Dockerfile" contains the best practice violation [DL3020](https://github.com/hadolint/hadolint/wiki/DL3020) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3020 occurs if ADD is used to copy files and directories that do not require tar self-extraction. In such cases, it is recommended to use the COPY instruction.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the ADD instruction is replaced by an equivalent COPY instruction.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance