### PR TITLE
Add column renderer to handle html in description

### DIFF
--- a/web/js/userTasksReport.js
+++ b/web/js/userTasksReport.js
@@ -141,6 +141,11 @@ Ext.onReady(function () {
         return id;
     };
 
+    /* Renderer for html */
+    function descriptionRenderer(text){
+        return Ext.util.Format.htmlEncode(text)
+    }
+
     /* Renderer to show the task type in the grid */
     function taskTypeRenderer(value) {
         var record =  taskTypeStore.getById(value);
@@ -472,6 +477,7 @@ Ext.onReady(function () {
             header: 'Description',
             sortable: true,
             dataIndex: 'text',
+            renderer: descriptionRenderer
         },{
             header: 'Story',
             sortable: true,


### PR DESCRIPTION
If someone has added an html element/tag inside their task description, the html gets rendered in the User Tasks report. In order to prevent this, I have added a small renderer function that uses one of Ext.js' native utils - an htmlEncoder. 

To test:
- Add a task with something like the following in the description: "Worked on adding support for <iframe> in XYZ repository"
- Save task
- Under 'Reports', choose 'User tasks'
- Select a date range that encompasses the task you just added
- Check to see if '<iframe>' is simply rendered as the element as text or if there is a blank iframe in the 'Description' column