### PR TITLE
Leave new records empty rather than prefill

### DIFF
--- a/web/js/areaManagement.js
+++ b/web/js/areaManagement.js
@@ -213,6 +213,7 @@ Ext.onReady(function(){
             editor: {
                 xtype: 'textfield',
                 allowBlank: false,
+                emptyText: 'Area name',
                 listeners: {
                     'change': function() {
                         this.setValue(this.getValue().trim());
@@ -244,9 +245,7 @@ Ext.onReady(function(){
          * onAdd
          */
         onAdd: function(btn, ev) {
-            var u = new areaRecord({
-                name: 'New Area',
-            });
+            var u = new areaRecord({});
             this.inlineEditor.stopEditing();
             this.store.insert(0, u);
             this.getView().refresh();

--- a/web/js/customerManagement.js
+++ b/web/js/customerManagement.js
@@ -315,6 +315,7 @@ Ext.onReady(function(){
             editor: {
                 xtype: 'textfield',
                 allowBlank: false,
+                emptyText: 'Client name',
                 listeners: {
                     'change': function() {
                         this.setValue(this.getValue().trim());
@@ -402,11 +403,7 @@ Ext.onReady(function(){
          * onAdd
          */
         onAdd: function(btn, ev) {
-            var u = new customerRecord({
-                name: 'New Client',
-                sectorId: sectorsStore.getAt(0).get('id'),
-                type: typesStore.getAt(0).get('name'),
-            });
+            var u = new customerRecord({});
             this.inlineEditor.stopEditing();
             this.store.insert(0, u);
             this.getView().refresh();
@@ -463,6 +460,7 @@ Ext.onReady(function(){
             editor: {
                 xtype: 'textfield',
                 allowBlank: false,
+                emptyText: 'sector name',
                 listeners: {
                     'change': function() {
                         this.setValue(this.getValue().trim());
@@ -494,9 +492,7 @@ Ext.onReady(function(){
          * onAdd
          */
         onAdd: function(btn, ev) {
-            var u = new sectorRecord({
-                name: 'New Sector',
-            });
+            var u = new sectorRecord({});
             this.inlineEditor.stopEditing();
             this.store.insert(0, u);
             this.getView().refresh();

--- a/web/viewUsers.php
+++ b/web/viewUsers.php
@@ -323,6 +323,7 @@ Ext.onReady(function(){
             editor: {
                 xtype: 'textfield',
                 allowBlank: false,
+                emptyText: 'login',
                 listeners: {
                     'change': function() {
                         this.setValue(this.getValue().trim());
@@ -338,6 +339,7 @@ Ext.onReady(function(){
             editor: {
                 xtype: 'textfield',
                 inputType: 'password',
+                emptyText: 'password',
                 allowBlank: true,
             }
         }<?php
@@ -374,9 +376,7 @@ Ext.onReady(function(){
          * onAdd
          */
         onAdd: function(btn, ev) {
-            var u = new userRecord({
-                login: 'New User',
-            });
+            var u = new userRecord({});
             this.inlineEditor.stopEditing();
             this.store.insert(0, u);
             this.getView().refresh();


### PR DESCRIPTION
Records added via the inline edit grids also prefill info and this can be a speedbump since users then have to delete the prefilled text in order to enter their own text. Instead, I propose leveraging the `emptyText` property in the editor which will add placeholder text that a user wouldn't have to delete.

Leaving this as draft for the moment so that folks can try it out to see if they agree with the new approach.