### PR TITLE
Display if project has hours logged in the future

### DIFF
--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -97,7 +97,6 @@ class PostgreSQLProjectDAO extends ProjectDAO {
         if(isset($row['customerid'])) {
             $projectVO->setCustomerId($row['customerid']);
         }
-        $projectVO->setFutureLoggedHours($row['futureLoggedHours']);
 
         return $projectVO;
 

--- a/model/vo/CustomProjectVO.php
+++ b/model/vo/CustomProjectVO.php
@@ -56,6 +56,7 @@ class CustomProjectVO extends ProjectVO {
      */
     protected $workedHours = NULL;
     protected $totalCost = NULL;
+    protected $futureLoggedHours = NULL;
 
     public function setTotalCost($totalCost) {
         if (is_null($totalCost))
@@ -187,6 +188,14 @@ class CustomProjectVO extends ProjectVO {
             return (100*$this->getWorkedHourInvoiceAbsoluteDeviation()/
                     $estHourInvoice);
         else return null;
+    }
+
+    public function getFutureLoggedHours() {
+        return $this->futureLoggedHours;
+    }
+
+    public function setFutureLoggedHours($futureHours = false) {
+        $this->futureLoggedHours = $futureHours;
     }
 
 }

--- a/model/vo/ProjectVO.php
+++ b/model/vo/ProjectVO.php
@@ -63,6 +63,7 @@ class ProjectVO {
     protected $movedHours = NULL;
     protected $schedType = NULL;
     protected $type = NULL;
+    protected $futureLoggedHours = NULL;
 
     public function setId($id) {
         if (is_null($id))
@@ -146,6 +147,14 @@ class ProjectVO {
 
     public function getMovedHours() {
         return $this->movedHours;
+    }
+
+    public function getFutureLoggedHours() {
+        return $this->futureLoggedHours;
+    }
+
+    public function setFutureLoggedHours($futureHours = false) {
+        $this->futureLoggedHours = $futureHours;
     }
 
     public function setAreaId($areaId) {

--- a/model/vo/ProjectVO.php
+++ b/model/vo/ProjectVO.php
@@ -63,7 +63,6 @@ class ProjectVO {
     protected $movedHours = NULL;
     protected $schedType = NULL;
     protected $type = NULL;
-    protected $futureLoggedHours = NULL;
 
     public function setId($id) {
         if (is_null($id))
@@ -147,14 +146,6 @@ class ProjectVO {
 
     public function getMovedHours() {
         return $this->movedHours;
-    }
-
-    public function getFutureLoggedHours() {
-        return $this->futureLoggedHours;
-    }
-
-    public function setFutureLoggedHours($futureHours = false) {
-        $this->futureLoggedHours = $futureHours;
     }
 
     public function setAreaId($areaId) {

--- a/web/js/projectDetailsReport.js
+++ b/web/js/projectDetailsReport.js
@@ -139,7 +139,16 @@ Ext.onReady(function(){
                         name:'workDeviationPercent',
                         fieldLabel: 'Deviation %',
                         value: projectData.workDeviationPercent,
-                    }
+                    },
+                    (projectData.futureLoggedHours > 0) ?
+                    {
+                        id: 'futureLoggedHours',
+                        name:'futureLoggedHours',
+                        fieldLabel: 'Hours Logged in The Future',
+                        value: projectData.futureLoggedHours,
+                        labelStyle: 'color:red; font-weight:bold;',
+                        style: {color:"red"},
+                    } : {},
                 ]
             },{
                 xtype: 'fieldset',

--- a/web/projectDetailsReport.php
+++ b/web/projectDetailsReport.php
@@ -65,6 +65,7 @@ echo "    active: " . ($project->getActivation()? "true":"false") . ",\n";
 echo "    movedHours: '" . $project->getMovedHours() . "',\n";
 echo "    invoice: '" . $project->getInvoice() . "',\n";
 echo "    type: '" . $project->getType() . "',\n";
+echo "    futureLoggedHours: '" . $project->getFutureLoggedHours() . "',\n";
 
 echo "    finalEstimatedHours: '" . $project->getFinalEstHours() . "',\n";
 echo "    workedHours: '" . $project->getWorkedHours() . "',\n";


### PR DESCRIPTION
Sometimes users can mistakenly log hours in the future and this was causing confusion because the total hours vs the hours displayed per user in the report didn't match.

With this patch, if a project has hours logged in the future a field with the amount of hours will be displayed in red in the project details report.

![Screenshot from 2023-04-19 13-49-30](https://user-images.githubusercontent.com/333447/233071494-93223a30-55d6-42cb-b4e8-9223f5f99866.png)

