### PR TITLE
Sort vacation users

### DIFF
--- a/web/js/holidaySummary.js
+++ b/web/js/holidaySummary.js
@@ -116,6 +116,7 @@ var app = new Vue({
             this.displayData = {};
             // Diplays only users from the project
             let users = this.projectUsers[project.id];
+            users.sort()
             for (let i = 0; i < users.length; i++) {
                 if (this.rawData[users[i]]) {
                     this.displayData[users[i]] = this.rawData[users[i]];

--- a/web/js/holidaySummary.js
+++ b/web/js/holidaySummary.js
@@ -74,6 +74,7 @@ var app = new Vue({
                     projectUsers.push(users[j].getElementsByTagName("login")[0].innerHTML);
                 }
                 this.projectUsers[parsedProjects[i].id] = projectUsers;
+                projectUsers.sort()
             }
             this.isLoadingProjects = false;
             this.projectsList = parsedProjects;


### PR DESCRIPTION
A tiny fix that ensures users remain sorted by username in the holiday/vacation summary report