### PR TITLE
Account for user journey when calculating days in summary

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -161,6 +161,12 @@ define('DAO_BACKEND', 'PostgreSQL');
 define ('YEARLY_HOLIDAY_HOURS', 184);
 
 /**
+ * @name STANDARD_WORKING_DAY
+ * @global int standard working day length (i.e., journey)
+ */
+define ('STANDARD_WORKING_DAY', 8);
+
+/**
  * @name ALL_USERS_GROUP
  * @global string users group used for retrieving all users
  */

--- a/config/config.template
+++ b/config/config.template
@@ -161,6 +161,13 @@ define('DAO_BACKEND', 'PostgreSQL');
 define ('YEARLY_HOLIDAY_HOURS', 184);
 
 /**
+ * @name STANDARD_WORKING_DAY
+ * @global int standard working day length (i.e., journey)
+ */
+define ('STANDARD_WORKING_DAY', 8);
+
+
+/**
  * @name ALL_USERS_GROUP
  * @global string users group used for retrieving all users
  */

--- a/config/config.test.php
+++ b/config/config.test.php
@@ -161,6 +161,13 @@ define('DAO_BACKEND', 'PostgreSQL');
 define ('YEARLY_HOLIDAY_HOURS', 184);
 
 /**
+ * @name STANDARD_WORKING_DAY
+ * @global int standard working day length (i.e., journey)
+ */
+define ('STANDARD_WORKING_DAY', 8);
+
+
+/**
  * @name ALL_USERS_GROUP
  * @global string users group used for retrieving all users
  */

--- a/model/facade/action/GetHolidaySummaryReportAction.php
+++ b/model/facade/action/GetHolidaySummaryReportAction.php
@@ -72,7 +72,7 @@ class GetHolidaySummaryReportAction extends GetHolidayHoursBaseAction
         );
         $validJourney = array_pop($validJourney);
         $validJourney = $validJourney ? $validJourney->getJourney() : 0;
-        $leaves = HolidayService::groupByWeeks($leaves, $this->weeks);
+        $leaves = HolidayService::groupByWeeks($leaves, $this->weeks, $journeyHistories);
         if (count($leaves) == 0) {
             $leaves = $this->weeks;
         }

--- a/web/js/holidayManagement.js
+++ b/web/js/holidayManagement.js
@@ -57,6 +57,11 @@ function formatMinutesToHours(minutes) {
     return minutesLeft > 0 ? hours + minutesLeft + "m" : hours;
 }
 
+function formatMinutesToDecimal(minutes){
+    let hours = (minutes / 60).toFixed(1);
+    return hours;
+}
+
 function addDays(date, days) {
     var result = new Date(date);
     result.setDate(result.getDate() + days);
@@ -258,6 +263,26 @@ var app = new Vue({
                         },
                         coveredDates: [d],
                     })
+                }
+                else {
+                   const durationInDecimal = formatMinutesToDecimal(datesAndRanges.dates[d].end - datesAndRanges.dates[d].init);
+                   const duration = formatMinutesToHours(datesAndRanges.dates[d].end - datesAndRanges.dates[d].init);
+                   const journeyDuration = formatMinutesToHours(datesAndRanges.journey * 60);
+                   if (durationInDecimal > datesAndRanges.journey)
+                   {
+                    datesAndRanges.dates[d].hoursOver = (durationInDecimal - datesAndRanges.journey).toFixed(1);
+                    attributes.push({
+                        highlight: {
+                            color: 'red',
+                            fillMode: 'light',
+                        },
+                        dates: new Date(d + 'T00:00:00'),
+                        popover: {
+                            label: `Vacation hours (${duration}) longer than workday hours (${journeyDuration})`
+                        },
+                        coveredDates: [d],
+                    })
+                   }
                 }
             });
             return {

--- a/web/services/HolidayService.php
+++ b/web/services/HolidayService.php
@@ -30,6 +30,7 @@ include_once(PHPREPORT_ROOT . '/model/facade/TasksFacade.php');
 include_once(PHPREPORT_ROOT . '/model/facade/UsersFacade.php');
 include_once(PHPREPORT_ROOT . '/model/vo/UserVO.php');
 require_once(PHPREPORT_ROOT . '/util/LoginManager.php');
+include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
 
 class HolidayService
 {
@@ -177,18 +178,24 @@ class HolidayService
         return $weeks;
     }
 
-    static function groupByWeeks(array $leavesDetails, $weeks = []): array
+    static function groupByWeeks(array $leavesDetails, $weeks = [], array $journeyHistories) : array
     {
         if (count($leavesDetails) == 0) return [];
         $dates = array_keys($leavesDetails);
         $previous_week = date("o\WW", strtotime($dates[0]));
         $weeks[$previous_week] = $leavesDetails[$dates[0]]['amount'] ?? 1;
         for ($i = 1; $i < count($dates); $i++) {
+            $currentJourney= array_filter($journeyHistories, fn($history) => $history->dateBelongsToHistory(date_create($dates[$i])))[0];
+            $journey = $currentJourney->getJourney() ?? \ConfigurationParametersManager::getParameter('STANDARD_WORKING_DAY');
             $current_week = date("o\WW", strtotime($dates[$i]));
             if ($current_week == $previous_week) {
-                $weeks[$current_week] += $leavesDetails[$dates[$i]]['amount'] ?? 1;
+                $leaveInDays = ($leavesDetails[$dates[$i]]['end'] - $leavesDetails[$dates[$i]]['init']) / 60;
+                $leavePerDayBasedOnJourney = $leaveInDays / $journey;
+                $weeks[$current_week] += $leavePerDayBasedOnJourney ?? 1;
             } else {
-                $weeks[$current_week] = $leavesDetails[$dates[$i]]['amount'] ?? 1;
+                $leaveInDays = ($leavesDetails[$dates[$i]]['end'] - $leavesDetails[$dates[$i]]['init']) / 60;
+                $leavePerDayBasedOnJourney = $leaveInDays / $journey;
+                $weeks[$current_week] = $leavePerDayBasedOnJourney ?? 1;
                 $previous_week = $current_week;
             }
             $weeks[$current_week] = round($weeks[$current_week], 2);
@@ -250,10 +257,16 @@ class HolidayService
         $vacations = \UsersFacade::GetScheduledHolidays($init, $end, $userVO);
         $vacations = $this::mapHalfLeaves($vacations, $journeyHistories);
 
+        for ($i = 1; $i < count($vacations); $i++){
+            $currentJourney = array_filter($journeyHistories, fn($history) => $history->dateBelongsToHistory(date_create($vacations[$i])))[0];
+        }
+
+        $journey = $currentJourney->getJourney() ?? \ConfigurationParametersManager::getParameter('STANDARD_WORKING_DAY');
         return [
             'dates' => $vacations,
             'ranges' => $this->datesToRanges(array_keys($vacations)),
-            'weeks' => $this->groupByWeeks($vacations)
+            'weeks' => $this->groupByWeeks($vacations, [], $journeyHistories),
+            'journey' => $journey
         ];
     }
 


### PR DESCRIPTION
Currently, the Vacation Management page shows Days Booked per Week and includes partial leaves (days where the number of of hours is less than a user journey), but doesn't account for a user booking more vacation hours than their workday hours (journey). This is normally not something to worry about too much since most users will probably use the Vacation Management page to book vacation and that interface takes care of handling the right amount of hours based on journey. However, if the user manually books vacation time via the Tasks page, there could be some days on which the user has more hours booked for vacation than they should. When this happens (more hours booked than should be allowed for a day), the Days Booked per Week does not take the user journey into account and will simply show 1 day booked on a week when it should perhaps show 1.25 days. 

This PR adds accounting for user journey in the calculation of Days Booked per Week and also adds highlighting to days on which a user has booked more vacation hours than their journey. 