### PR TITLE
Fix calculation of total minutes for overlapping tasks

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -255,7 +255,7 @@ function removeFreshEmptyTask() {
 function getMinutes(time){
     const hours = Number(time.split(':')[0]);
     const minutes = Number(time.split(':')[1]);
-    return hours + minutes;
+    return (hours * 60) + minutes;
 }
 
 function checkTaskForOverlap(store){


### PR DESCRIPTION
- Need to multiply hours by 60 to get total of minutes else evaluation of overlap can be wrong