### PR TITLE
Improve how to get env file and deprecate custom DAOs

### DIFF
--- a/model/dao/DAOFactory.php
+++ b/model/dao/DAOFactory.php
@@ -41,343 +41,208 @@ include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
  * @author Jacobo Aragunde Pérez <jaragunde@igalia.com>
  */
 
-class DAOFactory {
+class DAOFactory
+{
 
-
-    /** Sector DAO creator
-     *
-     * This function returns a new instance of {@link SectorDAO}.
-     *
-     * @return SectorDAO a new instance of {@link SectorDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getSectorDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('SECTOR_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'SectorDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/SectorDAO/' . $className . ".php");
-    return new $className;
+  /** Sector DAO creator
+   *
+   * This function returns a new instance of {@link SectorDAO}.
+   *
+   * @return SectorDAO a new instance of {@link SectorDAO}.
+   */
+  public static function getSectorDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/SectorDAO/PostgreSQLSectorDAO.php');
+    return new PostgreSQLSectorDAO;
   }
 
-    /** User DAO creator
-     *
-     * This function returns a new instance of {@link UserDAO}.
-     *
-     * @return UserDAO a new instance of {@link UserDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getUserDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('USER_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'UserDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/UserDAO/' . $className . ".php");
-    return new $className;
+  /** User DAO creator
+   *
+   * This function returns a new instance of {@link UserDAO}.
+   *
+   * @return UserDAO a new instance of {@link UserDAO}.
+   */
+  public static function getUserDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/UserDAO/PostgreSQLUserDAO.php');
+    return new PostgreSQLUserDAO;
   }
 
-    /** User Group DAO creator
-     *
-     * This function returns a new instance of {@link UserGroupDAO}.
-     *
-     * @return UserGroupDAO a new instance of {@link UserGroupDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getUserGroupDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('USER_GROUP_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'UserGroupDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/UserGroupDAO/' . $className . ".php");
-    return new $className;
+  /** User Group DAO creator
+   *
+   * This function returns a new instance of {@link UserGroupDAO}.
+   *
+   * @return UserGroupDAO a new instance of {@link UserGroupDAO}.
+   */
+  public static function getUserGroupDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/UserGroupDAO/PostgreSQLUserGroupDAO.php');
+    return new PostgreSQLUserGroupDAO;
   }
 
-    /** Belongs DAO creator
-     *
-     * This function returns a new instance of {@link BelongsDAO}.
-     *
-     * @return BelongsDAO a new instance of {@link BelongsDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getBelongsDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('BELONGS_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'BelongsDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/BelongsDAO/' . $className . ".php");
-    return new $className;
+  /** Belongs DAO creator
+   *
+   * This function returns a new instance of {@link BelongsDAO}.
+   *
+   * @return BelongsDAO a new instance of {@link BelongsDAO}.
+   */
+  public static function getBelongsDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/BelongsDAO/PostgreSQLBelongsDAO.php');
+    return new PostgreSQLBelongsDAO;
   }
 
-    /** Area DAO creator
-     *
-     * This function returns a new instance of {@link AreaDAO}.
-     *
-     * @return AreaDAO a new instance of {@link AreaDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getAreaDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('AREA_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'AreaDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/AreaDAO/' . $className . ".php");
-    return new $className;
+  /** Area DAO creator
+   *
+   * This function returns a new instance of {@link AreaDAO}.
+   *
+   * @return AreaDAO a new instance of {@link AreaDAO}.
+   */
+  public static function getAreaDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/AreaDAO/PostgreSQLAreaDAO.php');
+    return new PostgreSQLAreaDAO;
   }
 
-    /** Area History DAO creator
-     *
-     * This function returns a new instance of {@link AreaHistoryDAO}.
-     *
-     * @return AreaHistoryDAO a new instance of {@link AreaHistoryDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getAreaHistoryDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('AREA_HISTORY_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'AreaHistoryDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/AreaHistoryDAO/' . $className . ".php");
-    return new $className;
+  /** Area History DAO creator
+   *
+   * This function returns a new instance of {@link AreaHistoryDAO}.
+   *
+   * @return AreaHistoryDAO a new instance of {@link AreaHistoryDAO}.
+   */
+  public static function getAreaHistoryDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/AreaHistoryDAO/PostgreSQLAreaHistoryDAO.php');
+    return new PostgreSQLAreaHistoryDAO;
   }
 
   /**
    * @return UserGoalDAO
-   * @throws UnknownParameterException
    */
-  public static function getUserGoalDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('USER_GOAL_DAO');
-    } catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'UserGoalDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/UserGoalDAO/' . $className . ".php");
-    return new $className;
+  public static function getUserGoalDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/UserGoalDAO/PostgreSQLUserGoalDAO.php');
+    return new PostgreSQLUserGoalDAO;
   }
 
-    /** City DAO creator
-     *
-     * This function returns a new instance of {@link CityDAO}.
-     *
-     * @return CityDAO a new instance of {@link CityDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getCityDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('CITY_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'CityDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/CityDAO/' . $className . ".php");
-    return new $className;
+  /** City DAO creator
+   *
+   * This function returns a new instance of {@link CityDAO}.
+   *
+   * @return CityDAO a new instance of {@link CityDAO}.
+   */
+  public static function getCityDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/CityDAO/PostgreSQLCityDAO.php');
+    return new PostgreSQLCityDAO;
   }
 
-    /** City History DAO creator
-     *
-     * This function returns a new instance of {@link CityHistoryDAO}.
-     *
-     * @return CityHistoryDAO a new instance of {@link CityHistoryDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getCityHistoryDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('CITY_HISTORY_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'CityHistoryDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/CityHistoryDAO/' . $className . ".php");
-    return new $className;
+  /** City History DAO creator
+   *
+   * This function returns a new instance of {@link CityHistoryDAO}.
+   *
+   * @return CityHistoryDAO a new instance of {@link CityHistoryDAO}.
+   */
+  public static function getCityHistoryDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/CityHistoryDAO/PostgreSQLCityHistoryDAO.php');
+    return new PostgreSQLCityHistoryDAO;
   }
 
-    /** Common Event DAO creator
-     *
-     * This function returns a new instance of {@link CommonEventDAO}.
-     *
-     * @return CommonEventDAO a new instance of {@link CommonEventDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getCommonEventDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('COMMON_EVENT_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'CommonEventDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/CommonEventDAO/' . $className . ".php");
-    return new $className;
+  /** Common Event DAO creator
+   *
+   * This function returns a new instance of {@link CommonEventDAO}.
+   *
+   * @return CommonEventDAO a new instance of {@link CommonEventDAO}.
+   */
+  public static function getCommonEventDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/CommonEventDAO/PostgreSQLCommonEventDAO.php');
+    return new PostgreSQLCommonEventDAO;
   }
 
-    /** Customer DAO creator
-     *
-     * This function returns a new instance of {@link CustomerDAO}.
-     *
-     * @return CustomerDAO a new instance of {@link CustomerDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getCustomerDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('CUSTOMER_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'CustomerDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/CustomerDAO/' . $className . ".php");
-    return new $className;
+  /** Customer DAO creator
+   *
+   * This function returns a new instance of {@link CustomerDAO}.
+   *
+   * @return CustomerDAO a new instance of {@link CustomerDAO}.
+   */
+  public static function getCustomerDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/CustomerDAO/PostgreSQLCustomerDAO.php');
+    return new PostgreSQLCustomerDAO;
   }
 
-    /** Extra Hour DAO creator
-     *
-     * This function returns a new instance of {@link ExtraHourDAO}.
-     *
-     * @return ExtraHourDAO a new instance of {@link ExtraHourDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getExtraHourDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('EXTRA_HOUR_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'ExtraHourDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/ExtraHourDAO/' . $className . ".php");
-    return new $className;
+  /** Extra Hour DAO creator
+   *
+   * This function returns a new instance of {@link ExtraHourDAO}.
+   *
+   * @return ExtraHourDAO a new instance of {@link ExtraHourDAO}.
+   */
+  public static function getExtraHourDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/ExtraHourDAO/PostgreSQLExtraHourDAO.php');
+    return new PostgreSQLExtraHourDAO;
   }
 
-    /** Hour Cost History DAO creator
-     *
-     * This function returns a new instance of {@link HourCostHistoryDAO}.
-     *
-     * @return HourCostHistoryDAO a new instance of {@link HourCostHistoryDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getHourCostHistoryDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('HOUR_COST_HISTORY_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'HourCostHistoryDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/HourCostHistoryDAO/' . $className . ".php");
-    return new $className;
+  /** Hour Cost History DAO creator
+   *
+   * This function returns a new instance of {@link HourCostHistoryDAO}.
+   *
+   * @return HourCostHistoryDAO a new instance of {@link HourCostHistoryDAO}.
+   */
+  public static function getHourCostHistoryDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/HourCostHistoryDAO/PostgreSQLHourCostHistoryDAO.php');
+    return new PostgreSQLHourCostHistoryDAO;
   }
 
-    /** Journey History DAO creator
-     *
-     * This function returns a new instance of {@link JourneyHistoryDAO}.
-     *
-     * @return JourneyHistoryDAO a new instance of {@link JourneyHistoryDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getJourneyHistoryDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('JOURNEY_HISTORY_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'JourneyHistoryDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/JourneyHistoryDAO/' . $className . ".php");
-    return new $className;
+  /** Journey History DAO creator
+   *
+   * This function returns a new instance of {@link JourneyHistoryDAO}.
+   *
+   * @return JourneyHistoryDAO a new instance of {@link JourneyHistoryDAO}.
+   */
+  public static function getJourneyHistoryDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/JourneyHistoryDAO/PostgreSQLJourneyHistoryDAO.php');
+    return new PostgreSQLJourneyHistoryDAO;
   }
 
-    /** Project DAO creator
-     *
-     * This function returns a new instance of {@link ProjectDAO}.
-     *
-     * @return ProjectDAO a new instance of {@link ProjectDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getProjectDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('PROJECT_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'ProjectDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/ProjectDAO/' . $className . ".php");
-    return new $className;
+  /** Project DAO creator
+   *
+   * This function returns a new instance of {@link ProjectDAO}.
+   *
+   * @return ProjectDAO a new instance of {@link ProjectDAO}.
+   */
+  public static function getProjectDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/ProjectDAO/PostgreSQLProjectDAO.php');
+    return new PostgreSQLProjectDAO;
   }
 
-    /** Project User DAO creator
-     *
-     * This function returns a new instance of {@link ProjectUserDAO}.
-     *
-     * @return ProjectUserDAO a new instance of {@link ProjectUserDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getProjectUserDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('PROJECT_USER_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'ProjectUserDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/ProjectUserDAO/' . $className . ".php");
-    return new $className;
+  /** Project User DAO creator
+   *
+   * This function returns a new instance of {@link ProjectUserDAO}.
+   *
+   * @return ProjectUserDAO a new instance of {@link ProjectUserDAO}.
+   */
+  public static function getProjectUserDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/ProjectUserDAO/PostgreSQLProjectUserDAO.php');
+    return new PostgreSQLProjectUserDAO;
   }
 
-    /** Task DAO creator
-     *
-     * This function returns a new instance of {@link TaskDAO}.
-     *
-     * @return TaskDAO a new instance of {@link TaskDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getTaskDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('TASK_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'TaskDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/TaskDAO/' . $className . ".php");
-    return new $className;
+  /** Task DAO creator
+   *
+   * This function returns a new instance of {@link TaskDAO}.
+   *
+   * @return TaskDAO a new instance of {@link TaskDAO}.
+   */
+  public static function getTaskDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/TaskDAO/PostgreSQLTaskDAO.php');
+    return new PostgreSQLTaskDAO;
   }
 
   /** Template DAO creator
@@ -385,39 +250,22 @@ class DAOFactory {
    * This function returns a new instance of {@link TemplateDAO}.
    *
    * @return TemplateDAO a new instance of {@link TemplateDAO}.
-   * @throws {@link UnknownParameterException}
    */
-  public static function getTemplateDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('TEMPLATE_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'TemplateDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/TemplateDAO/' . $className . ".php");
-    return new $className;
+  public static function getTemplateDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/TemplateDAO/PostgreSQLTemplateDAO.php');
+    return new PostgreSQLTemplateDAO;
   }
 
-    /** Config DAO creator
-     *
-     * This function returns a new instance of {@link ConfigDAO}.
-     *
-     * @return ConfigDAO a new instance of {@link ConfigDAO}.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getConfigDAO() {
-    try {
-      $className = ConfigurationParametersManager::getParameter('CONFIG_DAO');
-    }
-    catch(UnknownParameterException $e) {
-      $backend = ConfigurationParametersManager::getParameter('DAO_BACKEND');
-      $className = $backend . 'ConfigDAO';
-    }
-
-    include_once(PHPREPORT_ROOT . '/model/dao/ConfigDAO/' . $className . ".php");
-    return new $className;
+  /** Config DAO creator
+   *
+   * This function returns a new instance of {@link ConfigDAO}.
+   *
+   * @return ConfigDAO a new instance of {@link ConfigDAO}.
+   */
+  public static function getConfigDAO()
+  {
+    include_once(PHPREPORT_ROOT . '/model/dao/ConfigDAO/PostgreSQLConfigDAO.php');
+    return new PostgreSQLConfigDAO;
   }
-
 }

--- a/util/ConfigurationParametersManager.php
+++ b/util/ConfigurationParametersManager.php
@@ -36,28 +36,28 @@ include_once(PHPREPORT_ROOT . '/util/UnknownParameterException.php');
  *
  * @see config.php
  */
-class ConfigurationParametersManager {
-    /** Parameters values retriever.
-     *
-     * This function retrieves the value of the parameter with the name <var>$parameterName</var>.
-     *
-     * @param string $parameterName the name of the parameter we want to retrieve.
-     * @return string the value of the parameter.
-     * @throws {@link UnknownParameterException}
-     */
-  public static function getParameter($parameterName) {
-    $parameterValue = getenv($parameterName);
-
-    if(!is_null($parameterValue) and $parameterValue != false){
-      return trim($parameterValue, '"');
+class ConfigurationParametersManager
+{
+  /** Parameters values retriever.
+   *
+   * This function retrieves the value of the parameter with the name <var>$parameterName</var>.
+   *
+   * @param string $parameterName the name of the parameter we want to retrieve.
+   * @return string the value of the parameter.
+   * @throws {@link UnknownParameterException}
+   */
+  public static function getParameter($parameterName)
+  {
+    if (!defined('ENV_LOADED')) {
+      $dotenv = Dotenv\Dotenv::createMutable(PHPREPORT_ROOT);
+      $dotenv->load();
+      define('ENV_LOADED', true);
     }
-    else {
-        $dotenv = Dotenv\Dotenv::createMutable(PHPREPORT_ROOT);
-        $dotenv->load();
-        $parameterValue = $_ENV[$parameterName];
 
-        if(!is_null($parameterValue))
-          return $parameterValue;
+    $parameterValue = $_SERVER[$parameterName];
+
+    if (!is_null($parameterValue) and $parameterValue !== false) {
+      return trim($parameterValue, '"');
     }
 
     throw new UnknownParameterException($parameterName);

--- a/web/services/getUserStoryReportJsonService.php
+++ b/web/services/getUserStoryReportJsonService.php
@@ -34,9 +34,9 @@
 
     $end = $_GET['end'];
 
-    $dateFormat = $_GET['dateFormat'];
+    $dateFormat = $_GET['dateFormat'] && NULL;
 
-    $sid = $_GET['sid'];
+    $sid = $_GET['sid'] && NULL;
 
     do {
 


### PR DESCRIPTION
- The env file was being loaded on every request, making the application slower.

- The custom DAO logic wasn't being used and only added complexity and unnecessary
checks on every request.