### PR TITLE
Add check for property before trying to filter on it

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -259,8 +259,8 @@ function getMinutes(time){
 }
 
 function checkTaskForOverlap(store){
-    let existingTasks = store.data.items.filter(x => !x.id.startsWith("ext"));
-    let unsavedTasks = store.data.items.filter(x => x.id.startsWith("ext"));
+    let existingTasks = store.data.items.filter(x => x.id && !x.id.startsWith("ext"));
+    let unsavedTasks = store.data.items.filter(x => x.id && x.id.startsWith("ext"));
 
     let overlapping = [];
     let overlapsTasks = false;


### PR DESCRIPTION
The check for tasks overlap function fails when copying tasks from another day, so we need to check for the existence of the property before filtering.