### PR TITLE
Ask to relogin only if response is 401

### DIFF
--- a/web/js/include/sessionTracker.js
+++ b/web/js/include/sessionTracker.js
@@ -23,11 +23,13 @@ function checkIfSessionExists() {
   Ext.Ajax.request({
     url: 'services/checkSessionActive.php',
     failure: function (response) {
-      Ext.MessageBox.confirm('Session Expired', 'Do you want to login again?', function (btn) {
-        if (btn === 'yes') {
-          window.location.reload();
-        }
-      });
+      if (response.status == 401) {
+        Ext.MessageBox.confirm('Session Expired', 'Do you want to login again?', function (btn) {
+          if (btn === 'yes') {
+            window.location.reload();
+          }
+        });
+      }
     },
     success: function (response) {
       Ext.MessageBox.hide();


### PR DESCRIPTION
The user is logged out only if the user wasn't found and therefore checkSessionActive.php returns 401. Other failures are probably transient or something that has nothing to do with the login.