### PR TITLE
Fix type annotation for python 3.9

### DIFF
--- a/api/schemas/project.py
+++ b/api/schemas/project.py
@@ -1,19 +1,20 @@
 from datetime import date
 
 from pydantic import BaseModel
+from typing import Optional
 
 
 class Project(BaseModel):
     id: str
     activation: bool
-    init: date | None
-    end: date | None
-    invoice: float | None
-    estimated_hours: float | None
-    moved_hours: float | None
-    description: str | None
-    project_type: str | None
-    schedule_type: str | None
+    init: Optional[date]
+    end: Optional[date]
+    invoice: Optional[float]
+    estimated_hours: Optional[float]
+    moved_hours: Optional[float]
+    description: Optional[str]
+    project_type: Optional[str]
+    schedule_type: Optional[str]
     customer_id: int
     area_id: int
 


### PR DESCRIPTION
The notation X | Y only works for python 3.10+