### PR TITLE
Change property that gets user from OIDC provider

### DIFF
--- a/util/LoginManager.php
+++ b/util/LoginManager.php
@@ -84,7 +84,7 @@ class LoginManager{
         $oidc = self::setupOidcClient();
 
         $oidc->authenticate();
-        $oidc_user = $oidc->requestUserInfo('sub');
+        $oidc_user = $oidc->requestUserInfo('preferred_username');
         $api_token = $oidc->getIdToken();
         $test = $oidc->getRefreshToken();
         $test2 = $oidc->refreshToken($test);


### PR DESCRIPTION
When switching to keycloak, the property used to fetch the username is different.