### PR TITLE
Remove vendor folders from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,2 @@
-vendor
-
-frontend/node_modules
-
 __pycache__
 .git


### PR DESCRIPTION
They are needed in order to run the apps - it was working in some cases where the dev had run composer install or npm install manually.