### PR TITLE
Add template endpoint

### DIFF
--- a/api/migrations/versions/39723f474338_add_column_to_template_table.py
+++ b/api/migrations/versions/39723f474338_add_column_to_template_table.py
@@ -1,0 +1,31 @@
+"""Add column to template table
+
+Revision ID: 39723f474338
+Revises: 3721dd962b84
+Create Date: 2023-09-12 12:34:48.059196
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "39723f474338"
+down_revision = "3721dd962b84"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("template", "usrid", nullable=True)
+    op.add_column("template", sa.Column("is_global", sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade() -> None:
+    # first, if we have any rows where usrid = null, set value to 0
+    template = sa.sql.table("template")
+    op.execute(template.update().where(template.c.usrid is None).values({"usrid": 0}))
+    # now set the column back to not nullable
+    op.alter_column("template", "usrid", nullable=False)
+    # remove column we added
+    op.drop_column("template", "is_global")

--- a/api/models/timelog.py
+++ b/api/models/timelog.py
@@ -63,13 +63,14 @@ class Template(Base):
     story = Column(String(length=80), nullable=True)
     telework = Column(Boolean, nullable=True)
     onsite = Column(Boolean, nullable=True)
-    text = Column(String(length=8192), nullable=True)
-    ttype = Column(String(length=40), nullable=True)
+    description = Column("text", String(length=8192), nullable=True)
+    task_type = Column("ttype", String(length=40), nullable=True)
     init_time = Column(Integer, nullable=True)
     end_time = Column(Integer, nullable=True)
-    customer = Column("customerid", Integer, ForeignKey("customer.id"), nullable=True)
-    user = Column("usrid", Integer, ForeignKey("usr.id"), nullable=False)
-    project = Column("projectid", Integer, ForeignKey("project.id"), nullable=True)
+    customer_id = Column("customerid", Integer, ForeignKey("customer.id"), nullable=True)
+    user_id = Column("usrid", Integer, ForeignKey("usr.id"), nullable=True)
+    project_id = Column("projectid", Integer, ForeignKey("project.id"), nullable=True)
+    is_global = Column(Boolean, nullable=False, default=False)
 
 
 class TotalHoursOverride(Base):

--- a/api/routers/v1/timelog.py
+++ b/api/routers/v1/timelog.py
@@ -2,8 +2,8 @@ from typing import List
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from schemas.timelog import TaskTypeItem
-from services.timelog import TaskTypeService
+from schemas.timelog import TaskTypeItem, Template as TemplateSchema
+from services.timelog import TaskTypeService, TemplateService
 
 from db.db_connection import get_db
 from auth.auth_bearer import BearerToken
@@ -15,3 +15,9 @@ router = APIRouter(prefix="/timelog", tags=["timelog"])
 async def get_task_types(db: Session = Depends(get_db), skip: int = 0, limit: int = 100):
     items = TaskTypeService(db).get_items()
     return items
+
+
+@router.get("/templates/{user_id}", dependencies=[Depends(BearerToken())], response_model=List[TemplateSchema])
+async def get_user_templates(user_id: int, db: Session = Depends(get_db)):
+    templates = TemplateService(db).get_user_templates(user_id)
+    return templates

--- a/api/schemas/timelog.py
+++ b/api/schemas/timelog.py
@@ -1,10 +1,28 @@
 from pydantic import BaseModel
+from typing import Optional
 
 
 class TaskTypeItem(BaseModel):
     slug: str
     name: str
     active: bool
+
+    class Config:
+        orm_mode = True
+
+
+class Template(BaseModel):
+    id: int
+    name: str
+    story: Optional[str]
+    description: Optional[str]
+    task_type: Optional[str]
+    init_time: Optional[int]
+    end_time: Optional[int]
+    customer_id: Optional[int]
+    user_id: Optional[int]
+    project_id: Optional[int]
+    is_global: bool
 
     class Config:
         orm_mode = True

--- a/api/services/timelog.py
+++ b/api/services/timelog.py
@@ -1,10 +1,19 @@
 from typing import List
+from sqlalchemy import or_
 
 from services.main import AppService
-from models.timelog import TaskType
+from models.timelog import TaskType, Template
 
 
 class TaskTypeService(AppService):
     def get_items(self) -> List[TaskType]:
         task_types = self.db.query(TaskType).all() or []
         return task_types
+
+
+class TemplateService(AppService):
+    def get_user_templates(self, user_id: int) -> List[Template]:
+        templates = (
+            self.db.query(Template).filter(or_(Template.user_id == user_id, Template.is_global is True)).all() or []
+        )
+        return templates


### PR DESCRIPTION
First, there are some small changes to the `template` table to allow for storage of global templates in the database.

Second, this adds a GET endpoint to the API to retriever user templates. This will get all templates the user has created as well as all global templates. 