### PR TITLE
Implement get_user_tasks endpoint

### DIFF
--- a/api/models/project.py
+++ b/api/models/project.py
@@ -1,5 +1,8 @@
 from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Date, Double
 import sqlalchemy as sa
+from sqlalchemy.orm import relationship, Mapped
+from sqlalchemy.ext.hybrid import hybrid_property
+from models.customer import Customer
 
 from db.base_class import Base
 
@@ -23,6 +26,11 @@ class Project(Base):
     schedule_type = Column("sched_type", String(length=256), nullable=True)
     customer_id = Column("customerid", ForeignKey("customer.id"))
     area_id = Column("areaid", ForeignKey("area.id"), nullable=False)
+    customer: Mapped["Customer"] = relationship()
+
+    @hybrid_property
+    def customer_name(self):
+        return self.customer.name
 
 
 class ProjectAssignment(Base):

--- a/api/models/timelog.py
+++ b/api/models/timelog.py
@@ -10,6 +10,9 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import relationship, Mapped
+from sqlalchemy.ext.hybrid import hybrid_property
+from models.project import Project
 
 from db.base_class import Base
 
@@ -23,15 +26,23 @@ class Task(Base):
     end = Column("_end", Integer, nullable=False)
     story = Column(String(length=80), nullable=True)
     telework = Column(Boolean, nullable=True)
-    text = Column(String(length=8192), nullable=True)
+    description = Column("text", String(length=8192), nullable=True)
     task_type = Column("ttype", String, ForeignKey("task_type.slug"), nullable=True)
     phase = Column(String(length=15), nullable=True)
     onsite = Column(Boolean, default=False, nullable=False)
     updated_at = Column(postgresql.TIMESTAMP(), nullable=True)
     end_after_init_task = CheckConstraint("_end >= init AND init >= 0", name="end_after_init_task")
-    customer = Column("customerid", Integer, ForeignKey("customer.id"), nullable=True)
-    user = Column("usrid", Integer, ForeignKey("usr.id"), nullable=False)
-    project = Column("projectid", Integer, ForeignKey("project.id"), nullable=False)
+    user_id = Column("usrid", Integer, ForeignKey("usr.id"), nullable=False)
+    project_id = Column("projectid", Integer, ForeignKey("project.id"), nullable=False)
+    project: Mapped["Project"] = relationship()
+
+    @hybrid_property
+    def project_name(self):
+        return self.project.description
+
+    @hybrid_property
+    def customer_name(self):
+        return self.project.customer_name
 
     __table_args__ = (UniqueConstraint("usrid", "init", "_date", name="unique_task_usr_time"),)
 

--- a/api/routers/v1/timelog.py
+++ b/api/routers/v1/timelog.py
@@ -1,9 +1,10 @@
 from typing import List
-from fastapi import APIRouter, Depends
+from datetime import date
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
-from schemas.timelog import TaskTypeItem, Template as TemplateSchema
-from services.timelog import TaskTypeService, TemplateService
+from schemas.timelog import TaskTypeItem, Template as TemplateSchema, Task as TaskSchema
+from services.timelog import TaskTypeService, TemplateService, TaskService
 
 from db.db_connection import get_db
 from auth.auth_bearer import BearerToken
@@ -21,3 +22,16 @@ async def get_task_types(db: Session = Depends(get_db), skip: int = 0, limit: in
 async def get_user_templates(user_id: int, db: Session = Depends(get_db)):
     templates = TemplateService(db).get_user_templates(user_id)
     return templates
+
+
+@router.get("/tasks", dependencies=[Depends(BearerToken())], response_model=List[TaskSchema])
+async def get_user_tasks(
+    user_id: int,
+    db: Session = Depends(get_db),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(25, ge=0, le=500),
+    start: date = date.today(),
+    end: date = date.today(),
+):
+    tasks = TaskService(db).get_user_tasks(user_id, offset, limit, start, end)
+    return tasks

--- a/api/schemas/customer.py
+++ b/api/schemas/customer.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class Customer(BaseModel):
+    id: int
+    name: str
+    customer_type: str
+    url: Optional[str]
+    sector_id: int
+
+    class Config:
+        orm_mode = True

--- a/api/schemas/timelog.py
+++ b/api/schemas/timelog.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pydantic import BaseModel
 from typing import Optional
 
@@ -23,6 +24,22 @@ class Template(BaseModel):
     user_id: Optional[int]
     project_id: Optional[int]
     is_global: bool
+
+    class Config:
+        orm_mode = True
+
+
+class Task(BaseModel):
+    id: int
+    date: date
+    init: int
+    end: int
+    story: Optional[str]
+    description: Optional[str]
+    task_type: Optional[str]
+    project_id: int
+    project_name: str
+    customer_name: Optional[str]
 
     class Config:
         orm_mode = True

--- a/api/services/timelog.py
+++ b/api/services/timelog.py
@@ -1,8 +1,9 @@
 from typing import List
+from datetime import date
 from sqlalchemy import or_
 
 from services.main import AppService
-from models.timelog import TaskType, Template
+from models.timelog import TaskType, Template, Task
 
 
 class TaskTypeService(AppService):
@@ -17,3 +18,16 @@ class TemplateService(AppService):
             self.db.query(Template).filter(or_(Template.user_id == user_id, Template.is_global is True)).all() or []
         )
         return templates
+
+
+class TaskService(AppService):
+    def get_user_tasks(self, user_id: int, offset: int, limit: int, start: date, end: date) -> List[Task]:
+        tasks = (
+            self.db.query(Task)
+            .where(Task.user_id == user_id, Task.date.between(start, end))
+            .offset(offset)
+            .limit(limit)
+            .all()
+            or []
+        )
+        return tasks


### PR DESCRIPTION
- Add schemas for task and customer
- Add method to timelog service for fetching tasks
- Modify models for project and task as needed

These changes implement a basic GET endpoint for user tasks. As the amount of tasks fetched could grow to be very large, I have added both offset/limit and date range query params so that the frontend consumer is not overwhelmed with data. 