### PR TITLE
Fix type of project id

### DIFF
--- a/api/schemas/project.py
+++ b/api/schemas/project.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 
 class Project(BaseModel):
-    id: str
+    id: int
     is_active: bool
     init: Optional[date] = None
     end: Optional[date] = None


### PR DESCRIPTION
/projects/{project_id} GET endpoint was erroring out due to a type mismatch. This commit aligns the schema property with the model.