### PR TITLE
Fix link to documentation workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Test](https://github.com/Igalia/phpreport/actions/workflows/runtests.yml/badge.svg)](https://github.com/Igalia/phpreport/actions/workflows/runtests.yml)
-[![Documentation](https://github.com/Igalia/phpreport/actions/workflows/publish-docs.yml/badge.svg)](https://github.com/Igalia/phpreport/actions/workflows/mdbook.yml)
+[![Documentation](https://github.com/Igalia/phpreport/actions/workflows/mdbook.yml/badge.svg)](https://github.com/Igalia/phpreport/actions/workflows/mdbook.yml)
 
 # PhpReport
 


### PR DESCRIPTION
I don't know how I missed the broken badge before, but this should fix.