### PR TITLE
Default env variables for tests to None

### DIFF
--- a/api/auth/auth_handler.py
+++ b/api/auth/auth_handler.py
@@ -8,8 +8,8 @@ JWT_SECRET = config("JWT_SECRET")
 JWT_ALGORITHM = config("JWT_ALGORITHM")
 JWT_AUDIENCE = config("JWT_AUDIENCE")
 OIDC_CERTS_URL = config("OIDC_CERTS_URL")
-JWT_PUB_KEY = config("JWT_PUB_KEY")
-JWT_PRIVATE_KEY = config("JWT_PRIVATE_KEY")
+JWT_PUB_KEY = config("JWT_PUB_KEY", None)
+JWT_PRIVATE_KEY = config("JWT_PRIVATE_KEY", None)
 
 
 def token_response(token: str):


### PR DESCRIPTION
It seems that `decouple` doesn't resolve a not-found .env variable to None by default. Since the JWT_PUB_KEY and JWT_PRIVATE_KEY are here just for testing, we should probably force the default to None so that `decouple` doesn't toss errors when running for development.