### PR TITLE
Split front and back tests in GH actions

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run the containers
-        run: docker-compose -f ./docker/docker-compose.test.yml up -d
+        run: docker-compose -f ./docker/docker-compose.test.yml up -d phpreport-app api test_db
       - name: Wait
         run: sleep 15s
       - name: Run tests
@@ -23,5 +23,18 @@ jobs:
         run: docker exec -t phpreport-api tox -e black
       - name: Run API tests
         run: docker exec -t phpreport-api tox -e pytest
-      - name: Run jest
-        run: docker exec -t phpreport-frontend npm run test
+  test_frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      - name: Install deps
+        run: npm install
+      - name: Run frontend tests
+        run: npm run test


### PR DESCRIPTION
The frontend tests don't need to run on docker nor need the DB running so better to split them to get an easier to read output.