### PR TITLE
Add user capacity to AppUser object

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -30,6 +30,7 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: Se
         first_name=decoded["given_name"],
         last_name=decoded["family_name"],
         roles=[],
+        capacities=user_in_db.capacities,
     )
     if USE_OIDC_ROLES:
         user.roles = decoded[OIDC_ROLES_PROPERTY].copy()

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -1,10 +1,20 @@
 from typing import List, Optional
 from pydantic import ConfigDict, BaseModel
+from datetime import date
+
+
+class UserCapacity(BaseModel):
+    capacity: Optional[float] = None
+    start: Optional[date] = None
+    end: Optional[date] = None
+    is_current: Optional[bool] = None
+    model_config = ConfigDict(from_attributes=True)
 
 
 class User(BaseModel):
     id: int
     login: str
+    capacities: Optional[List[UserCapacity]] = None
     model_config = ConfigDict(from_attributes=True)
 
 
@@ -26,3 +36,5 @@ class AppUser(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     roles: Optional[List[str]] = None
+    capacities: Optional[List[UserCapacity]] = None
+    model_config = ConfigDict(from_attributes=True)

--- a/frontend/src/domain/User.ts
+++ b/frontend/src/domain/User.ts
@@ -7,4 +7,12 @@ export type User = {
   firstName: string
   lastName: string
   roles: Roles
+  capacities: Array<UserCapacity>
+}
+
+type UserCapacity = {
+  capacity: number
+  start: string
+  end: string
+  isCurrent: boolean
 }


### PR DESCRIPTION
This adds the 'capacities' list to the User object in front and back end. A capacity is defined here as the number of hours a user works per week for the provided timeframe. We use the capacity to do several of the calculations in the summary, so it makes sense to include it as part of the user payload.