### PR TITLE
Patch login service

### DIFF
--- a/util/LoginManager.php
+++ b/util/LoginManager.php
@@ -43,7 +43,7 @@ require_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
  */
 class LoginManager
 {
-  private static function setupOidcClient()
+  public static function setupOidcClient()
   {
     $client = new Client(
       ConfigurationParametersManager::getParameter('OIDC_AUTHORITY'),

--- a/web/services/loginService.php
+++ b/web/services/loginService.php
@@ -30,6 +30,8 @@
     include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
     include_once(PHPREPORT_ROOT . '/model/facade/UsersFacade.php');
     include_once(PHPREPORT_ROOT . '/model/vo/UserVO.php');
+    include_once(PHPREPORT_ROOT . '/util/ConfigurationParametersManager.php');
+    include_once(PHPREPORT_ROOT . '/util/LoginManager.php');
 
     /* Allow login only via HTTP Authentication data only if both username and password are not empty*/
     if (!isset($_SERVER['PHP_AUTH_USER']) || !isset($_SERVER['PHP_AUTH_PW'])) {
@@ -46,11 +48,52 @@
     $string = "";
 
     try{
-
-        $user = UsersFacade::Login($userLogin, $userPassword);
-
         session_start();
 
+        if (strtolower(ConfigurationParametersManager::getParameter('USE_EXTERNAL_AUTHENTICATION')) === 'true') {
+            $clientId = ConfigurationParametersManager::getParameter('OIDC_CLIENT_ID');
+            $clientSecret = ConfigurationParametersManager::getParameter('JWT_SECRET');
+            $requestUri = ConfigurationParametersManager::getParameter('OIDC_TOKEN_ENDPOINT');
+            $ch = curl_init();
+            $params = "username=" . $userLogin . "&password=" . $userPassword . "&grant_type=password&client_id=" . $clientId . "&client_secret=" . $clientSecret;
+            $headers = array(
+                "Content-type: application/x-www-form-urlencoded"
+            );
+
+            curl_setopt($ch, CURLOPT_URL, $requestUri);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            $result = curl_exec($ch);
+            $decoded = json_decode($result, true);
+
+            curl_close($ch);
+
+            $api_token = $decoded["access_token"];
+            $refresh_token = $decoded["refresh_token"];
+
+            $oidc = LoginManager::setupOidcClient();
+            $intro_token = $oidc->introspectToken(
+                $api_token,
+                null,
+                $clientId,
+                $clientSecret
+            );
+
+            $user = UsersFacade::GetUserByLogin($intro_token->username);
+            if (!$user)
+                throw new IncorrectLoginException("User not found");
+
+            unset($_SESSION['api_token']);
+            $_SESSION['api_token'] = $api_token;
+            unset($_SESSION['refresh_token']);
+            $_SESSION['refresh_token'] = $refresh_token;
+
+        } else {
+            $user = UsersFacade::Login($userLogin, $userPassword);
+        }
+        unset($_SESSION['user']);
         $_SESSION['user'] = $user;
 
         $sessionId = session_id();


### PR DESCRIPTION
- Make oidc client init method public so it can be used elsewhere
- Add check for use of external auth. If using, make a curl request to the token endpoint to log user in with OIDC, set access token and user.


The loginService.php is only used with the old API and it needs to bypass the OAuth provider login page and redirect. This is why the auth request here is made via curl to the token endpoint. 