### PR TITLE
Update schemas to return camel case json

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -5,7 +5,7 @@ from fastapi.security import OAuth2PasswordBearer
 from decouple import config
 from db.db_connection import get_db
 from auth.auth_handler import decode_token
-from schemas.user import AppUser
+from schemas.user import AppUser, UserCapacity
 from services.user import UserService
 
 
@@ -30,8 +30,12 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)], db: Se
         first_name=decoded["given_name"],
         last_name=decoded["family_name"],
         roles=[],
-        capacities=user_in_db.capacities,
+        capacities=[],
     )
+    for c in user_in_db.capacities:
+        cap = UserCapacity(capacity=c.capacity, start=c.start, end=c.end, is_current=c.is_current)
+        user.capacities.append(cap)
+
     if USE_OIDC_ROLES:
         user.roles = decoded[OIDC_ROLES_PROPERTY].copy()
     else:

--- a/api/schemas/customer.py
+++ b/api/schemas/customer.py
@@ -1,4 +1,5 @@
 from pydantic import ConfigDict, BaseModel
+from pydantic.alias_generators import to_camel
 from typing import Optional
 
 
@@ -8,4 +9,4 @@ class Customer(BaseModel):
     customer_type: str
     url: Optional[str] = None
     sector_id: int
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)

--- a/api/schemas/project.py
+++ b/api/schemas/project.py
@@ -1,6 +1,6 @@
 from datetime import date
-
 from pydantic import ConfigDict, BaseModel
+from pydantic.alias_generators import to_camel
 from typing import Optional
 
 
@@ -16,5 +16,6 @@ class Project(BaseModel):
     project_type: Optional[str] = None
     schedule_type: Optional[str] = None
     customer_id: int
+    customer_name: Optional[str] = None
     area_id: int
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)

--- a/api/schemas/timelog.py
+++ b/api/schemas/timelog.py
@@ -1,5 +1,12 @@
 from datetime import date
-from pydantic import StringConstraints, ConfigDict, BaseModel, computed_field, model_validator
+from pydantic import (
+    StringConstraints,
+    ConfigDict,
+    BaseModel,
+    computed_field,
+    model_validator,
+)
+from pydantic.alias_generators import to_camel
 from typing import Optional, Any
 from typing_extensions import Annotated
 from helpers.time import time_string_to_int
@@ -9,11 +16,12 @@ class TaskTypeItem(BaseModel):
     slug: str
     name: str
     active: bool
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 # Shared properties
 class TemplateBase(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     name: Optional[Annotated[str, StringConstraints(max_length=80)]] = None
     story: Optional[Annotated[str, StringConstraints(max_length=80)]] = None
     description: Optional[Annotated[str, StringConstraints(max_length=8192)]] = None
@@ -66,7 +74,6 @@ class TemplateInDb(TemplateBase):
     id: int
     init: Optional[int]
     end: Optional[int]
-    model_config = ConfigDict(from_attributes=True)
 
 
 # Properties to return to client
@@ -77,6 +84,7 @@ class Template(TemplateBase):
 
 # Shared properties
 class TaskBase(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     date: Optional[date]
     story: Optional[Annotated[str, StringConstraints(max_length=80)]] = None
     description: Optional[Annotated[str, StringConstraints(max_length=8192)]] = None
@@ -137,7 +145,6 @@ class TaskInDb(TaskBase):
     init: int
     end: int
     date: date
-    model_config = ConfigDict(from_attributes=True)
 
 
 # Properties to return to client

--- a/api/schemas/user.py
+++ b/api/schemas/user.py
@@ -1,35 +1,38 @@
 from typing import List, Optional
-from pydantic import ConfigDict, BaseModel
+from decimal import Decimal
+from pydantic import ConfigDict, BaseModel, Field
+from pydantic.alias_generators import to_camel
 from datetime import date
 
 
 class UserCapacity(BaseModel):
-    capacity: Optional[float] = None
+    capacity: Decimal = Field(max_digits=4, decimal_places=2)
     start: Optional[date] = None
     end: Optional[date] = None
     is_current: Optional[bool] = None
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class User(BaseModel):
     id: int
     login: str
     capacities: Optional[List[UserCapacity]] = None
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class UserGroup(BaseModel):
     id: int
     name: str
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class UserRoles(BaseModel):
     role: UserGroup
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
 class AppUser(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     id: Optional[int] = None
     username: Optional[str] = None
     email: Optional[str] = None
@@ -37,4 +40,3 @@ class AppUser(BaseModel):
     last_name: Optional[str] = None
     roles: Optional[List[str]] = None
     capacities: Optional[List[UserCapacity]] = None
-    model_config = ConfigDict(from_attributes=True)

--- a/api/tests/routers/v1/test_timelog.py
+++ b/api/tests/routers/v1/test_timelog.py
@@ -26,7 +26,9 @@ def test_get_user_cannot_get_templates_from_other_user(
     client: TestClient, get_regular_user_token_headers: Dict[str, str]
 ) -> None:
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 2}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 2},
     )
     assert response.status_code == HTTPStatus.FORBIDDEN
     content = response.json()
@@ -40,29 +42,31 @@ def test_get_user_and_global_templates(client: TestClient, get_regular_user_toke
             "name": "Coffee Break",
             "story": "coffee",
             "description": "Need to recharge",
-            "task_type": "meeting",
-            "start_time": "0:00",
-            "end_time": "7:00",
-            "user_id": 1,
-            "is_global": False,
-            "project_id": None,
+            "taskType": "meeting",
+            "startTime": "0:00",
+            "endTime": "7:00",
+            "userId": 1,
+            "isGlobal": False,
+            "projectId": None,
         },
         {
             "id": 3,
             "name": "Working at night",
             "story": None,
             "description": "Working late",
-            "task_type": "meeting",
-            "start_time": "20:00",
-            "end_time": "22:00",
-            "user_id": None,
-            "is_global": True,
-            "project_id": None,
+            "taskType": "meeting",
+            "startTime": "20:00",
+            "endTime": "22:00",
+            "userId": None,
+            "isGlobal": True,
+            "projectId": None,
         },
     ]
 
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 1}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 1},
     )
     assert response.status_code == HTTPStatus.OK
     templates = response.json()
@@ -75,15 +79,17 @@ def test_create_user_template(client: TestClient, get_regular_user_token_headers
         "name": "Full work day",
         "story": "work",
         "description": "Just a regular day",
-        "start_time": "9:00",
-        "end_time": "17:00",
-        "task_type": "meeting",
-        "project_id": 1,
-        "user_id": 1,
-        "is_global": False,
+        "startTime": "9:00",
+        "endTime": "17:00",
+        "taskType": "meeting",
+        "projectId": 1,
+        "userId": 1,
+        "isGlobal": False,
     }
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 1}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 1},
     )
     assert response.status_code == HTTPStatus.OK
     templates = response.json()
@@ -102,17 +108,19 @@ def test_create_user_template(client: TestClient, get_regular_user_token_headers
         "name": "Full work day",
         "story": "work",
         "description": "Just a regular day",
-        "start_time": "9:00",
-        "end_time": "17:00",
-        "project_id": 1,
-        "user_id": 1,
-        "is_global": False,
-        "task_type": "meeting",
+        "startTime": "9:00",
+        "endTime": "17:00",
+        "projectId": 1,
+        "userId": 1,
+        "isGlobal": False,
+        "taskType": "meeting",
     }
     assert response.json() == expected_response
 
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 1}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 1},
     )
     assert response.status_code == HTTPStatus.OK
     templates = response.json()
@@ -126,10 +134,10 @@ def test_regular_user_cannot_create_global_template(
         "name": "TGIF",
         "story": "no work",
         "description": "No work on Friday",
-        "start_time": "0:00",
-        "end_time": "0:00",
-        "project_id": 1,
-        "is_global": True,
+        "startTime": "0:00",
+        "endTime": "0:00",
+        "projectId": 1,
+        "isGlobal": True,
     }
 
     response = client.post(
@@ -151,10 +159,10 @@ def test_regular_user_cannot_create_template_for_another_user(
         "name": "TGIF",
         "story": "no work",
         "description": "No work on Friday",
-        "start_time": "0:00",
-        "end_time": "0:00",
-        "project_id": 1,
-        "is_global": True,
+        "startTime": "0:00",
+        "endTime": "0:00",
+        "projectId": 1,
+        "isGlobal": True,
     }
 
     response = client.post(
@@ -174,11 +182,11 @@ def test_update_user_template(client: TestClient, get_regular_user_token_headers
         "name": "Coffee Break updated",
         "story": "coffee time",
         "description": "Need to recharge again",
-        "task_type": "meeting",
-        "start_time": "15:00",
-        "end_time": "15:30",
-        "project_id": 1,
-        "user_id": 1,
+        "taskType": "meeting",
+        "startTime": "15:00",
+        "endTime": "15:30",
+        "projectId": 1,
+        "userId": 1,
     }
 
     response = client.put(
@@ -194,12 +202,12 @@ def test_update_user_template(client: TestClient, get_regular_user_token_headers
         "name": "Coffee Break updated",
         "story": "coffee time",
         "description": "Need to recharge again",
-        "task_type": "meeting",
-        "start_time": "15:00",
-        "end_time": "15:30",
-        "project_id": 1,
-        "is_global": False,
-        "user_id": 1,
+        "taskType": "meeting",
+        "startTime": "15:00",
+        "endTime": "15:30",
+        "projectId": 1,
+        "isGlobal": False,
+        "userId": 1,
     }
 
     res = response.json()
@@ -209,7 +217,7 @@ def test_update_user_template(client: TestClient, get_regular_user_token_headers
 def test_update_nonexistent_template(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
     template_payload = {
         "name": "Fake template",
-        "user_id": 1,
+        "userId": 1,
     }
 
     response = client.put(
@@ -228,8 +236,8 @@ def test_cannot_update_other_users_template(client: TestClient, get_regular_user
     template_payload = {
         "name": "Series time",
         "description": "Watching Tuca and Bertie",
-        "user_id": 2,
-        "is_global": False,
+        "userId": 2,
+        "isGlobal": False,
     }
 
     response = client.put(
@@ -246,7 +254,9 @@ def test_cannot_update_other_users_template(client: TestClient, get_regular_user
 def test_delete_template(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
     # Check existing templates first
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 1}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 1},
     )
     assert response.status_code == HTTPStatus.OK
     templates = response.json()
@@ -261,7 +271,9 @@ def test_delete_template(client: TestClient, get_regular_user_token_headers: Dic
 
     # There should be only one template now
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/templates/", headers=get_regular_user_token_headers, params={"user_id": 1}
+        f"{API_BASE_URL}/v1/timelog/templates/",
+        headers=get_regular_user_token_headers,
+        params={"user_id": 1},
     )
     assert response.status_code == HTTPStatus.OK
     templates = response.json()
@@ -296,16 +308,16 @@ def test_get_user_tasks(client: TestClient, get_regular_user_token_headers: Dict
     expected_tasks = [
         {
             "id": 1,
-            "user_id": 1,
+            "userId": 1,
             "date": "2023-10-20",
             "description": "Working in that awesome project",
-            "start_time": "20:00",
-            "end_time": "22:00",
-            "project_id": 2,
-            "project_name": "Internal",
-            "customer_name": "Internal Customer",
+            "startTime": "20:00",
+            "endTime": "22:00",
+            "projectId": 2,
+            "projectName": "Internal",
+            "customerName": "Internal Customer",
             "story": "that project",
-            "task_type": "project",
+            "taskType": "project",
         },
     ]
 
@@ -337,11 +349,11 @@ def test_create_task(client: TestClient, get_regular_user_token_headers: Dict[st
         "date": "2023-10-21",
         "story": "project",
         "description": "Adding tests",
-        "task_type": "project",
-        "project_id": 1,
-        "user_id": 1,
-        "start_time": "08:30",
-        "end_time": "14:00",
+        "taskType": "project",
+        "projectId": 1,
+        "userId": 1,
+        "startTime": "08:30",
+        "endTime": "14:00",
     }
     response = client.get(
         f"{API_BASE_URL}/v1/timelog/tasks/",
@@ -365,13 +377,13 @@ def test_create_task(client: TestClient, get_regular_user_token_headers: Dict[st
         "date": "2023-10-21",
         "story": "project",
         "description": "Adding tests",
-        "task_type": "project",
-        "project_id": 1,
-        "user_id": 1,
-        "start_time": "8:30",
-        "end_time": "14:00",
-        "project_name": "Holidays",
-        "customer_name": "Internal Customer",
+        "taskType": "project",
+        "projectId": 1,
+        "userId": 1,
+        "startTime": "8:30",
+        "endTime": "14:00",
+        "projectName": "Holidays",
+        "customerName": "Internal Customer",
     }
     assert response.json() == expected_response
 
@@ -392,11 +404,11 @@ def test_regular_user_cannot_create_tasks_for_other_users(
         "date": "2023-10-21",
         "story": "project",
         "description": "Adding tests",
-        "task_type": "project",
-        "project_id": 1,
-        "user_id": 2,
-        "start_time": "08:30",
-        "end_time": "14:00",
+        "taskType": "project",
+        "projectId": 1,
+        "userId": 2,
+        "startTime": "08:30",
+        "endTime": "14:00",
     }
     response = client.post(
         f"{API_BASE_URL}/v1/timelog/tasks",
@@ -412,9 +424,9 @@ def test_regular_user_cannot_create_tasks_for_other_users(
 def test_update_task(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
     task_payload = {
         "date": "2023-10-22",
-        "start_time": "10:00",
-        "end_time": "12:00",
-        "user_id": 1,
+        "startTime": "10:00",
+        "endTime": "12:00",
+        "userId": 1,
     }
 
     response = client.put(
@@ -428,16 +440,16 @@ def test_update_task(client: TestClient, get_regular_user_token_headers: Dict[st
 
     expected_task = {
         "id": 1,
-        "user_id": 1,
+        "userId": 1,
         "date": "2023-10-22",
         "description": "Working in that awesome project",
-        "start_time": "10:00",
-        "end_time": "12:00",
-        "project_id": 2,
-        "project_name": "Internal",
-        "customer_name": "Internal Customer",
+        "startTime": "10:00",
+        "endTime": "12:00",
+        "projectId": 2,
+        "projectName": "Internal",
+        "customerName": "Internal Customer",
         "story": "that project",
-        "task_type": "project",
+        "taskType": "project",
     }
 
     res = response.json()
@@ -505,11 +517,11 @@ def test_user_cannot_create_task_with_overlapping_hours(
         "date": "2023-10-20",
         "story": "project",
         "description": "Overlapping time with task 1",
-        "task_type": "project",
-        "project_id": 1,
-        "user_id": 1,
-        "start_time": "20:30",
-        "end_time": "23:00",
+        "taskType": "project",
+        "projectId": 1,
+        "userId": 1,
+        "startTime": "20:30",
+        "endTime": "23:00",
     }
 
     response = client.post(

--- a/api/tests/utils/mock_data.py
+++ b/api/tests/utils/mock_data.py
@@ -15,7 +15,14 @@ DATA = [
             {"login": "manager", "password": "manager"},
         ],
     ),
-    (UserGroup, [{"id": 1, "name": "staff"}, {"id": 2, "name": "admin"}, {"id": 3, "name": "manager"}]),
+    (
+        UserGroup,
+        [
+            {"id": 1, "name": "staff"},
+            {"id": 2, "name": "admin"},
+            {"id": 3, "name": "manager"},
+        ],
+    ),
     (
         UserRoles,
         [
@@ -41,8 +48,18 @@ DATA = [
     (
         Project,
         [
-            {"description": "Holidays", "area_id": 1, "customer_id": 1, "is_active": True},
-            {"description": "Internal", "area_id": 1, "customer_id": 1, "is_active": True},
+            {
+                "description": "Holidays",
+                "area_id": 1,
+                "customer_id": 1,
+                "is_active": True,
+            },
+            {
+                "description": "Internal",
+                "area_id": 1,
+                "customer_id": 1,
+                "is_active": True,
+            },
         ],
     ),
     (


### PR DESCRIPTION
- Use alias generator from pydantic to emit camel case and set populate_by_name to true so validation does not fail
- Update fill of capacities list in get_current_user due to model type mismatch after update of schemas
- Update json in tests to match new schema

Regarding the second item here: prior to changing the model_config for UserCapacity, it seems that the mapping from model.user.UserCapacity => schemas.user.UserCapacity happened under the hood easily. After the change, pydantic was quite unhappy about the type mismatch, so I did a simple iterate and append. If I missed some easier way to address this, please let me know.

This was the error received after the model config change:
```
File "/usr/local/lib/python3.9/dist-packages/pydantic/main.py", line 164, in __init__
2023-11-10 11:02:13     __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
2023-11-10 11:02:13 pydantic_core._pydantic_core.ValidationError: 1 validation error for AppUser
2023-11-10 11:02:13 capacities.0
2023-11-10 11:02:13   Input should be a valid dictionary or instance of UserCapacity [type=model_type, input_value=<models.user.UserCapacity...bject at 0x7f82fb06d430>, input_type=UserCapacity]
2023-11-10 11:02:13     For further information visit https://errors.pydantic.dev/2.4/v/model_type
```