### PR TITLE
Add migration for archive table and trigger

### DIFF
--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -39,7 +39,12 @@ prepend_sys_path = .
 
 # Logging configuration
 [loggers]
-keys = root,sqlalchemy,alembic
+keys = root,sqlalchemy,alembic,alembic_utils
+
+[logger_alembic_utils]
+level = INFO
+handlers =
+qualname = alembic_utils
 
 [handlers]
 keys = console

--- a/api/db/base.py
+++ b/api/db/base.py
@@ -7,3 +7,4 @@ from models.user import *
 from models.sector import *
 from models.timelog import *
 from models.city import *
+from models.archive import *

--- a/api/migrations/versions/dc2b619f65a9_add_archive_table_and_triggers.py
+++ b/api/migrations/versions/dc2b619f65a9_add_archive_table_and_triggers.py
@@ -1,0 +1,127 @@
+"""Add archive table and triggers
+
+Revision ID: dc2b619f65a9
+Revises: 72e6af46be22
+Create Date: 2023-11-14 11:17:57.848580
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+
+
+# revision identifiers, used by Alembic.
+revision = 'dc2b619f65a9'
+down_revision = '72e6af46be22'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('archive',
+    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+    sa.Column('table_name', sa.VARCHAR(length=100), nullable=True),
+    sa.Column('record_type', sa.VARCHAR(length=100), nullable=True),
+    sa.Column('record_id', sa.INTEGER(), nullable=True),
+    sa.Column('operation', sa.VARCHAR(length=50), nullable=True),
+    sa.Column('old_values', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+    sa.Column('new_values', postgresql.JSON(astext_type=sa.Text()), nullable=True),
+    sa.Column('most_recent', sa.BOOLEAN(), nullable=True),
+    sa.Column('recorded_at', postgresql.TIMESTAMP(), nullable=True),
+    sa.PrimaryKeyConstraint('id'))
+
+    make_archive_of_changes = PGFunction(
+            schema="public",
+            signature="make_archive_of_changes()",
+            definition="""
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $function$
+            -- Expects one argument, the record_type
+            -- It's the stringified ActiveRecord class name
+            -- For example 'User', or 'Task'
+            BEGIN
+                UPDATE archive
+                SET most_recent = FALSE
+                WHERE
+                table_name = TG_TABLE_NAME
+                AND most_recent = TRUE
+                AND record_type = record_type
+                AND record_id = (
+                    CASE WHEN TG_OP = 'DELETE'
+                    THEN OLD.id
+                    ELSE NEW.id
+                    END
+                );
+
+
+                IF TG_OP = 'INSERT' THEN
+                INSERT INTO archive (
+                    table_name, record_type, record_id, operation, new_values, most_recent, recorded_at
+                )
+                VALUES (
+                    TG_TABLE_NAME, TG_ARGV[0], NEW.id, TG_OP, row_to_json(NEW), TRUE, now()
+                );
+                RETURN NEW;
+
+                ELSIF TG_OP = 'UPDATE' THEN
+                INSERT INTO archive (
+                    table_name, record_type, record_id, operation, new_values, old_values, most_recent, recorded_at
+                )
+                VALUES (
+                    TG_TABLE_NAME, TG_ARGV[0], NEW.id, TG_OP, row_to_json(NEW), row_to_json(OLD), TRUE, now()
+                );
+                RETURN NEW;
+
+                ELSIF TG_OP = 'DELETE' THEN
+                INSERT INTO archive (
+                    table_name, record_type, record_id, operation, old_values, most_recent, recorded_at
+                )
+                VALUES (
+                    TG_TABLE_NAME, TG_ARGV[0], OLD.id, TG_OP, row_to_json(OLD), TRUE, now()
+                );
+                RETURN OLD;
+
+                END IF;
+            END;
+            $function$
+            ;
+            """
+    )
+
+    op.create_entity(make_archive_of_changes)
+
+    project_trigger = PGTrigger(
+        schema="public",
+        signature="trg_make_archive_of_changes_for_projects",
+        on_entity="public.project",
+        definition="""
+        after insert or delete or update on
+            public.project for each row execute function make_archive_of_changes('Project')
+        """
+    )
+    op.create_entity(project_trigger)
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    op.drop_table('archive')
+    # remove triggers
+    project_trigger = PGTrigger(
+        schema="public",
+        signature="trg_make_archive_of_changes_for_projects",
+        on_entity="public.project",
+        definition="# Not used"
+    )
+    op.drop_entity(project_trigger)
+    # remove function
+    make_archive_of_changes = PGFunction(
+        schema="public",
+        signature="make_archive_of_changes()",
+        definition="# Not Used"
+    )
+    op.drop_entity(make_archive_of_changes)
+
+    # ### end Alembic commands ###

--- a/api/models/archive.py
+++ b/api/models/archive.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Boolean, JSON, DateTime
+from db.base_class import Base
+
+
+class Archive(Base):
+    id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    table_name = Column(String(length=100), nullable=True)
+    record_type = Column(String(length=100), nullable=True)
+    record_id = Column(Integer, nullable=True)
+    operation = Column(String(length=50), nullable=True)
+    old_values = Column(JSON, nullable=True)
+    new_values = Column(JSON, nullable=True)
+    most_recent = Column(Boolean, nullable=True)
+    recorded_at = Column(DateTime, nullable=True)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pydantic == 2.4.2",
     "psycopg2-binary == 2.9.6",
     "alembic == 1.10.4",
+    "alembic_utils == 0.8.2",
     "sqlalchemy == 2.0.12",
     "fastapi >= 0.95.2",
     "tox==4.6.3",

--- a/docs/src/developer/devel-setup.md
+++ b/docs/src/developer/devel-setup.md
@@ -116,6 +116,21 @@ alembic revision --autogenerate -m "Migrations description"
 
 For more details check the alembic documentation.
 
+### History tracking in database
+As part of the migrations, an `archive` table is added to the database along with a function to log to this table and a trigger to captures changes on the `project` table. A trigger using this function can be added to track the history of any table. To do so, create a migration with the following (with the `customer` table used as an example):
+```py
+    customer_trigger = PGTrigger(
+        schema="public",
+        signature="trg_make_archive_of_changes_for_customers",
+        on_entity="public.customer",
+        definition="""
+        after insert or delete or update on
+            public.customer for each row execute function make_archive_of_changes('Customer')
+        """
+    )
+    op.create_entity(customer_trigger)
+```
+
 ## Setting up the files
 
 Clone the PhpReport repository `https://github.com/Igalia/phpreport` in


### PR DESCRIPTION
- Add alembic_utils to package list
- Add necessary logging configs per alembic_utils docs
- Create migration that adds archive table, adds function that logs to table, and add trigger to project table
- Add model for archive table 
- Add information to docs on how to add a trigger to other tables that use the logging function