### PR TITLE
Add totp param to passthrough to oauth

### DIFF
--- a/web/services/loginService.php
+++ b/web/services/loginService.php
@@ -56,6 +56,11 @@
             $requestUri = ConfigurationParametersManager::getParameter('OIDC_TOKEN_ENDPOINT');
             $ch = curl_init();
             $params = "username=" . $userLogin . "&password=" . $userPassword . "&grant_type=password&client_id=" . $clientId . "&client_secret=" . $clientSecret;
+            if(isset($_GET['totp'])){
+                $totp = $_GET['totp'];
+                $params = $params . '&totp=' . $totp;
+            }
+
             $headers = array(
                 "Content-type: application/x-www-form-urlencoded"
             );


### PR DESCRIPTION
- Add totp so that users with 2FA will be able to use this service

A previous patch added a cURL request to the external auth provider, but did not take into account 2FA. This patch fixes that issue by accepting a 'totp' param in the url which can be passed to the OAuth provider.