### PR TITLE
Fix: Set used hours to 0 if the date is in the future

### DIFF
--- a/model/facade/action/GetHolidayHoursBaseAction.php
+++ b/model/facade/action/GetHolidayHoursBaseAction.php
@@ -135,7 +135,14 @@ abstract class GetHolidayHoursBaseAction extends Action
                 $userAvailableHours[$userVO->getLogin()] = $holidayHours;
 
                 $referenceDate = $referenceDate ?? new DateTime();
-                $userUsedHours[$userVO->getLogin()] = $taskDao->getVacations($userVO, $reportInit, $referenceDate)["add_hours"] ?? 0;
+                //if the reference data is in the future, then usedHours has to be 0 - we are not time travelers
+                if($referenceDate > new DateTime()){
+                    $userUsedHours[$userVO->getLogin()] = 0;
+                }
+                else {
+                    $userUsedHours[$userVO->getLogin()] = $taskDao->getVacations($userVO, $reportInit, $referenceDate)["add_hours"] ?? 0;
+                }
+
                 $userScheduledHours[$userVO->getLogin()] = $vacations - $userUsedHours[$userVO->getLogin()];
 
                 // The difference is the number of pending holiday hours


### PR DESCRIPTION
The holiday summary for an upcoming year was improperly calculating and showing some hours as used, which should not be possible. This solution checks the referenceDate passed to the method doing the calculation and if it is in the future, the used hours are set to 0.