### PR TITLE
Fix useGetCurrentUser breaking on server

### DIFF
--- a/frontend/src/hooks/useGetCurrentUser/useGetCurrentUser.ts
+++ b/frontend/src/hooks/useGetCurrentUser/useGetCurrentUser.ts
@@ -1,9 +1,14 @@
 import { useSession } from 'next-auth/react'
+import { Session } from 'next-auth'
 
 export const useGetCurrentUser = () => {
   const { data } = useSession({
     required: true
   })
 
-  return data!.user
+  if (!data) {
+    return {} as Session['user']
+  }
+
+  return data.user
 }


### PR DESCRIPTION
If session data doesn't exist, it only returns an empty object