### PR TITLE
Fix task types dropdown

### DIFF
--- a/api/routers/v1/timelog.py
+++ b/api/routers/v1/timelog.py
@@ -35,17 +35,18 @@ router = APIRouter(
 
 
 @router.get(
-    "/task_types/",
+    "/task_types",
     response_model=List[TaskTypeItem],
     dependencies=[Depends(PermissionsValidator(required_permissions=["task_type:read"]))],
 )
 async def get_task_types(
     current_user=Depends(get_current_user),
     db: Session = Depends(get_db),
+    active: bool = True,
     skip: int = 0,
     limit: int = 100,
 ):
-    items = TaskTypeService(db).get_items()
+    items = TaskTypeService(db).get_items(active)
     return items
 
 

--- a/api/services/timelog.py
+++ b/api/services/timelog.py
@@ -10,8 +10,12 @@ from schemas.validation import ValidatedObject
 
 
 class TaskTypeService(AppService):
-    def get_items(self) -> List[TaskType]:
-        task_types = self.db.query(TaskType).all() or []
+    def get_items(self, active) -> List[TaskType]:
+        query = self.db.query(TaskType)
+        if active:
+            print(active)
+            query = query.filter(TaskType.active == True)
+        task_types = query.order_by(TaskType.name).all() or []
         return task_types
 
     def slug_is_valid(self, slug: str) -> bool:

--- a/api/services/timelog.py
+++ b/api/services/timelog.py
@@ -13,8 +13,7 @@ class TaskTypeService(AppService):
     def get_items(self, active) -> List[TaskType]:
         query = self.db.query(TaskType)
         if active:
-            print(active)
-            query = query.filter(TaskType.active == True)
+            query = query.filter(TaskType.active)
         task_types = query.order_by(TaskType.name).all() or []
         return task_types
 

--- a/api/tests/routers/v1/test_timelog.py
+++ b/api/tests/routers/v1/test_timelog.py
@@ -20,7 +20,10 @@ def test_get_task_types_authenticated(client: TestClient, get_regular_user_token
     task_types = response.json()
     assert task_types == expected_types
 
-def test_get_task_types_including_inactive_ones(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
+
+def test_get_task_types_including_inactive_ones(
+    client: TestClient, get_regular_user_token_headers: Dict[str, str]
+) -> None:
     expected_types = [
         {"slug": "deprecated", "name": "Deprecated Type", "active": False},
         {"slug": "meeting", "name": "Meeting", "active": True},

--- a/api/tests/routers/v1/test_timelog.py
+++ b/api/tests/routers/v1/test_timelog.py
@@ -9,13 +9,28 @@ API_BASE_URL = config("API_BASE_URL")
 def test_get_task_types_authenticated(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
     expected_types = [
         {"slug": "meeting", "name": "Meeting", "active": True},
-        {"slug": "deprecated", "name": "Deprecated Type", "active": False},
         {"slug": "project", "name": "Project time", "active": True},
     ]
 
     response = client.get(
-        f"{API_BASE_URL}/v1/timelog/task_types/",
+        f"{API_BASE_URL}/v1/timelog/task_types",
         headers=get_regular_user_token_headers,
+    )
+    assert response.status_code == HTTPStatus.OK
+    task_types = response.json()
+    assert task_types == expected_types
+
+def test_get_task_types_including_inactive_ones(client: TestClient, get_regular_user_token_headers: Dict[str, str]) -> None:
+    expected_types = [
+        {"slug": "deprecated", "name": "Deprecated Type", "active": False},
+        {"slug": "meeting", "name": "Meeting", "active": True},
+        {"slug": "project", "name": "Project time", "active": True},
+    ]
+
+    response = client.get(
+        f"{API_BASE_URL}/v1/timelog/task_types",
+        headers=get_regular_user_token_headers,
+        params={"active": False},
     )
     assert response.status_code == HTTPStatus.OK
     task_types = response.json()

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1352,7 +1352,12 @@ Ext.onReady(function(){
                     // Create and populate a record
                     var newTask = new taskRecord();
                     newTask.set('projectId', templateValues['projectId']);
-                    newTask.set('ttype', templateValues['ttype']);
+                    if(templateValues && !taskTypeStore.data.items.includes(x => x.id == templateValues['ttype'])){
+                      let message = `Task type of ${templateValues['ttype']} is not valid. The task type may have been deactivated. Please choose another task type.`
+                      App.setAlert(false, message);
+                      } else {
+                        newTask.set('ttype', templateValues['ttype']);
+                    }
                     newTask.set('story', templateValues['story']);
                     newTask.set('text', templateValues['text']);
                     newTask.set('initTime', templateValues['initTime']);

--- a/web/services/getTaskTypes.php
+++ b/web/services/getTaskTypes.php
@@ -55,7 +55,7 @@ do {
         break;
     }
 
-    $taskTypes = makeAPIRequest("/v1/timelog/task_types/");
+    $taskTypes = makeAPIRequest("/v1/timelog/task_types");
     if (array_key_exists('token_refresh_error', $taskTypes)) {
         $response['success'] = false;
         $response['error'] = 'token_refresh_error';


### PR DESCRIPTION
There were 2 issues in our task types dropdown:

- when typing in the field, the autocomplete was displaying inactive task types as if they were still active.
- if a user had an inactive task type saved as a template, they could still use it.

This PR adds a filter in the endpoint that allows us to get only the active task types and it adds a check to validate the task type when a user uses a template.