### PR TITLE
Allow templates with empty task types

### DIFF
--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -1352,7 +1352,7 @@ Ext.onReady(function(){
                     // Create and populate a record
                     var newTask = new taskRecord();
                     newTask.set('projectId', templateValues['projectId']);
-                    if(templateValues && !taskTypeStore.data.items.some(x => x.id == templateValues['ttype'])){
+                    if(templateValues && templateValues['ttype'] && !taskTypeStore.data.items.some(x => x.id == templateValues['ttype'])){
                       let message = `Task type of ${templateValues['ttype']} is not valid. The task type may have been deactivated. Please choose another task type.`
                       App.setAlert(false, message);
                       } else {


### PR DESCRIPTION
If a user had a template with no task type they couldn't use it.