### PR TITLE
Disallow log time to projects user is not assigned

### DIFF
--- a/docs/src/user/tasks.md
+++ b/docs/src/user/tasks.md
@@ -25,10 +25,8 @@ some are used to fill the information about the task:
 
 - Time: fill the start and end dates in.
 - Project: project the task belongs to. You may search by the project
-  or the customer name. There is one special entry in the combo box,
-  _Load all projects_, that would let you load the complete list of
-  projects in the system; users will only see projects they are
-  assigned to by default.
+  or the customer name, users will only see projects they are
+  assigned to.
 - Story: you can fill this field with a keyword to help you to
   differentiate tasks inside the same project.
 - Description: the big text area in the center can be used to write a

--- a/web/js/tasks.js
+++ b/web/js/tasks.js
@@ -349,6 +349,8 @@ function addNewTaskIfEmpty() {
     }
 }
 
+let projectsList = [];
+
 /*  Class that stores a taskRecord element and shows it on screen.
     It keeps the taskRecord in synch with the content of the form on screen,
     in real-time (as soon as it changes). */
@@ -460,14 +462,7 @@ var TaskPanel = Ext.extend(Ext.Panel, {
                     remoteSort: false,
                     listeners: {
                         'load': function (store) {
-                            var dummyRecord = new projectRecord({
-                                id: -1,                  // some invalid id
-                                fullDescription: "Load all projects",
-                                customerName: ""
-                            });
-
-                            store.add(dummyRecord);
-                            store.commitChanges();
+                            projectsList = this.parent.projectComboBox.store.data.items;
 
                             //the value of projectComboBox has to be set after loading the data on this store
                             if ((this.findExact("id", this.parent.taskRecord.data['projectId']) == -1) &&
@@ -1351,12 +1346,18 @@ Ext.onReady(function(){
 
                     // Create and populate a record
                     var newTask = new taskRecord();
-                    newTask.set('projectId', templateValues['projectId']);
                     if(templateValues && templateValues['ttype'] && !taskTypeStore.data.items.some(x => x.id == templateValues['ttype'])){
                       let message = `Task type of ${templateValues['ttype']} is not valid. The task type may have been deactivated. Please choose another task type.`
                       App.setAlert(false, message);
                       } else {
                         newTask.set('ttype', templateValues['ttype']);
+                    }
+
+                    if(templateValues && !projectsList.some(x => x.id == templateValues['projectId'])){
+                        let message = `You are not assigned to this project. Please select another project or contact the system administrators.`
+                        App.setAlert(false, message);
+                    } else {
+                        newTask.set('projectId', templateValues['projectId']);
                     }
                     newTask.set('story', templateValues['story']);
                     newTask.set('text', templateValues['text']);


### PR DESCRIPTION
Remove load all projects feature and make sure when loading from templates the users can't log time into projects they are not assigned to.