### PR TITLE
Fix ProjectAssignment primary keys

### DIFF
--- a/api/migrations/versions/217cb64b0391_initial_db_creation.py
+++ b/api/migrations/versions/217cb64b0391_initial_db_creation.py
@@ -195,7 +195,7 @@ def upgrade() -> None:
         sa.Column('projectid', sa.Integer(), nullable=False),
         sa.ForeignKeyConstraint(['projectid'], ['project.id'], ),
         sa.ForeignKeyConstraint(['usrid'], ['usr.id'], ),
-        sa.PrimaryKeyConstraint('usrid')
+        sa.PrimaryKeyConstraint('usrid', 'projectid')
         )
 
     # ----------------------------------------------------------------------

--- a/api/models/project.py
+++ b/api/models/project.py
@@ -35,4 +35,4 @@ class ProjectAssignment(Base):
     __tablename__ = "project_usr"
 
     user = Column("usrid", Integer, ForeignKey("usr.id"), nullable=False, primary_key=True)
-    project = Column("projectid", Integer, ForeignKey("project.id"), nullable=False)
+    project = Column("projectid", Integer, ForeignKey("project.id"), nullable=False, primary_key=True)


### PR DESCRIPTION
It should be a composed primary key of user and project, not just the user id.