### PR TITLE
Add ctrl+s save to edit form

### DIFF
--- a/frontend/src/app/tasks/components/EditTask.tsx
+++ b/frontend/src/app/tasks/components/EditTask.tsx
@@ -22,11 +22,12 @@ type EditTaskProps = {
 }
 
 export const EditTask = ({ task, tasks, projects, taskTypes, closeForm }: EditTaskProps) => {
-  const { handleChange, handleProject, formState, handleSubmit, resetForm } = useEditTaskForm({
-    task,
-    tasks,
-    closeForm
-  })
+  const { handleChange, handleProject, formState, handleSubmit, resetForm, formRef } =
+    useEditTaskForm({
+      task,
+      tasks,
+      closeForm
+    })
 
   return (
     <Stack
@@ -34,6 +35,7 @@ export const EditTask = ({ task, tasks, projects, taskTypes, closeForm }: EditTa
         e.preventDefault()
         handleSubmit()
       }}
+      ref={formRef}
       component="form"
       gap="8px"
       width="400px"

--- a/frontend/src/app/tasks/hooks/useCreateTaskForm.ts
+++ b/frontend/src/app/tasks/hooks/useCreateTaskForm.ts
@@ -102,7 +102,7 @@ export const useTaskForm = () => {
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
-      if (event.key === 's' && event.ctrlKey) {
+      if (event.key === 's' && event.ctrlKey && formRef.current?.contains(document.activeElement)) {
         event.preventDefault()
         formRef.current?.requestSubmit()
       }

--- a/frontend/src/app/tasks/hooks/useEditTaskForm.ts
+++ b/frontend/src/app/tasks/hooks/useEditTaskForm.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 import { useAlert } from '@/ui/Alert/useAlert'
 import { useForm } from '@/hooks/useForm/useForm'
@@ -16,6 +16,8 @@ export const useEditTaskForm = ({ task, tasks, closeForm }: UseEditTaskFormProps
   const { formState, handleChange, resetForm } = useForm<TaskIntent>({
     initialValues: task
   })
+  const formRef = useRef<HTMLFormElement>(null)
+
   const { showError } = useAlert()
   const { editTask } = useEditTask({ handleSuccess: closeForm })
 
@@ -53,5 +55,19 @@ export const useEditTaskForm = ({ task, tasks, closeForm }: UseEditTaskFormProps
     }
   }
 
-  return { formState, handleChange, handleSubmit, resetForm, handleProject }
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === 's' && event.ctrlKey && formRef.current?.contains(document.activeElement)) {
+        event.preventDefault()
+        formRef.current?.requestSubmit()
+      }
+    }
+    document.addEventListener('keydown', handleKeyPress)
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress)
+    }
+  }, [handleSubmit])
+
+  return { formState, handleChange, handleSubmit, resetForm, handleProject, formRef }
 }


### PR DESCRIPTION
Pressing Ctrl+S will try to save the current active form.

[Screencast from 2023-12-21 12-20-47.webm](https://github.com/Igalia/phpreport/assets/20492786/9027eb98-451c-438f-b8bf-886d07402816)
