### PR TITLE
Enable leave projects to everyone

### DIFF
--- a/api/tests/utils/mock_data.py
+++ b/api/tests/utils/mock_data.py
@@ -1,6 +1,6 @@
 from models.area import Area
 from models.customer import Customer
-from models.project import Project, ProjectAllocation
+from models.project import Project, ProjectAllocation, ProjectAssignment
 from models.timelog import Task, TaskType, Template
 from models.user import User, UserGroup, UserRoles
 from models.sector import Sector
@@ -124,6 +124,15 @@ DATA = [
                 "is_tentative": False,
                 "is_billable": True,
                 "notes": "test",
+            }
+        ],
+    ),
+    (
+        ProjectAssignment,
+        [
+            {
+                "user": 2,
+                "project": 1,
             }
         ],
     ),

--- a/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
+++ b/model/dao/ProjectDAO/PostgreSQLProjectDAO.php
@@ -361,7 +361,10 @@ class PostgreSQLProjectDAO extends ProjectDAO {
         $conditions = "TRUE";
 
         if ($userLogin) {
-            $userCondition = "project.id IN (SELECT projectid FROM project_usr LEFT JOIN usr ON project_usr.usrid=usr.id " . "WHERE login=" . DBPostgres::checkStringNull( $userLogin ) . ") ";
+            // if filtering by user return the projects the user is assigned to but also the leave projects
+            // since everyone should be able to use them even if not assigned to
+            $userCondition = "(project.id IN (SELECT projectid FROM project_usr LEFT JOIN usr ON project_usr.usrid=usr.id " . "WHERE login=" . DBPostgres::checkStringNull( $userLogin ) . ") ";
+            $userCondition .= " OR project.type = 'leave') ";
         }
         if ($active) {
             $activeCondition = "activation='True'";

--- a/web/services/createTasksService.php
+++ b/web/services/createTasksService.php
@@ -29,6 +29,7 @@
     define('PHPREPORT_ROOT', __DIR__ . '/../../');
     include_once(PHPREPORT_ROOT . '/web/services/WebServicesFunctions.php');
     include_once(PHPREPORT_ROOT . '/model/facade/TasksFacade.php');
+    include_once(PHPREPORT_ROOT . '/model/facade/ProjectsFacade.php');
     include_once(PHPREPORT_ROOT . '/model/vo/TaskVO.php');
     include_once(PHPREPORT_ROOT . '/model/OperationResult.php');
 
@@ -207,9 +208,15 @@
 
                 $taskVO->setUserId($user->getId());
 
-                if (is_null($taskVO->getProjectId()))
+                // Get projects user is assigned to to make sure they can log time to them
+                $projects = ProjectsFacade::GetAllProjects($user->getLogin());
+                $projectIdList = [];
+                foreach ($projects as $project) {
+                    $projectIdList[] = $project->getId();
+                }
+                if (is_null($taskVO->getProjectId()) || !in_array($taskVO->getProjectId(), $projectIdList))
                 {
-                    $string = "<return service='createTasks'><success>false</success><error id='4'>projectId is not valid</error></return>";
+                    $string = "<return service='createTasks'><success>false</success><error id='4'>Project is not valid or you are not allowed to log time to this project</error></return>";
                     break;
                 }
                 //Support 0-hour tasks: reparse end time if initTime == 0 to the end so that order of parse doesn't cause error if end time added before init time by users


### PR DESCRIPTION
Instead of having to manually assign everyone to all the leave projects, return them when fetching user's projects.
Also check if they can log time to a project before creating a task.