### PR TITLE
Add work summary panel

### DIFF
--- a/api/helpers/time.py
+++ b/api/helpers/time.py
@@ -1,4 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, date
+import math
 
 
 def time_string_to_int(time_string: str) -> int:
@@ -21,3 +22,41 @@ def total_hours_between_dates(start_date, end_date, hours_per_weekday):
         current_date += timedelta(days=1)
 
     return total_hours
+
+
+def int_to_time_long_string(time_minutes: int) -> str:
+    return int_to_time_string(time_minutes).replace(":", "h ") + "m"
+
+
+def vacation_int_to_string(time_minutes: int, user_capacity: float) -> str:
+    if time_minutes == 0:
+        return "None"
+
+    hours_total = math.floor(time_minutes / 60)
+    remaining_total_minutes = time_minutes % 60
+    days = math.floor(time_minutes / (user_capacity * 60))
+    leftover_minutes = time_minutes % (user_capacity * 60)
+    hours = math.floor(leftover_minutes / 60)
+    mins = time_minutes - (days * (user_capacity * 60)) - (hours * 60)
+
+    vacation_time_string = ""
+    if days > 0:
+        vacation_time_string += f"{days} days"
+    if hours > 0:
+        vacation_time_string += " " if days > 0 else ""
+        vacation_time_string += f"{hours} h"
+    if mins > 0:
+        vacation_time_string += " " if hours > 0 or days > 0 else ""
+        vacation_time_string += f"{mins:.0f} m"
+    if hours_total > 0 or remaining_total_minutes > 0:
+        hours_total_string = f"{hours_total} h" if hours_total > 0 else ""
+        remaining_mins_string = f" {remaining_total_minutes} m" if remaining_total_minutes > 0 else ""
+        vacation_time_string += f" ({hours_total_string}{remaining_mins_string})"
+
+    return f"{vacation_time_string}"
+
+def get_start_and_end_date_of_isoweek(current_date: date) -> []:
+    weekday = current_date.isoweekday()
+    start = current_date - timedelta(days=weekday)
+    end = start + timedelta(days=6)
+    return [start, end]

--- a/api/helpers/time.py
+++ b/api/helpers/time.py
@@ -1,5 +1,7 @@
+from typing import List
 from datetime import timedelta, date
 import math
+from models.user import UserCapacity
 
 
 def time_string_to_int(time_string: str) -> int:
@@ -55,8 +57,22 @@ def vacation_int_to_string(time_minutes: int, user_capacity: float) -> str:
 
     return f"{vacation_time_string}"
 
+
 def get_start_and_end_date_of_isoweek(current_date: date) -> []:
     weekday = current_date.isoweekday()
     start = current_date - timedelta(days=weekday)
     end = start + timedelta(days=6)
     return [start, end]
+
+
+def get_expected_worked_hours(user_capacities: List[UserCapacity], start_date: date, end_date: date) -> float:
+    end_date = end_date + timedelta(days=1)
+    days_in_range = (start_date + timedelta(x) for x in range((end_date - start_date).days))
+    expected = 0
+    for day in days_in_range:
+        if day.weekday() > 4:
+            continue
+        capacity = [x.capacity for x in user_capacities if day >= x.start and day <= x.end]
+        if capacity:
+            expected = expected + capacity[0]
+    return expected

--- a/api/schemas/timelog.py
+++ b/api/schemas/timelog.py
@@ -7,7 +7,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic.alias_generators import to_camel
-from typing import Optional, Any
+from typing import Optional, Any, List
 from typing_extensions import Annotated
 from helpers.time import time_string_to_int
 
@@ -152,3 +152,35 @@ class Task(TaskBase):
     id: int
     project_name: str
     customer_name: Optional[str] = None
+
+
+class ProjectTaskSummary(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    project_id: Optional[int] = None
+    project: Optional[str] = None
+    today_total: Optional[int] = None
+    today_text: Optional[str] = None
+    week_total: Optional[int] = None
+    week_text: Optional[str] = None
+    is_vacation: bool
+
+
+class Summary(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+    today: Optional[int] = 0
+    week: Optional[int] = 0
+    today_text: Optional[str] = None
+    week_text: Optional[str] = None
+    project_summaries: List[ProjectTaskSummary] = None
+    vacation_available: Optional[int] = None
+    vacation_available_text: Optional[str] = None
+    vacation_used: Optional[int] = None
+    vacation_used_text: Optional[str] = None
+    vacation_scheduled: Optional[int] = None
+    vacation_scheduled_text: Optional[str] = None
+    vacation_pending: Optional[int] = None
+    vacation_pending_text: Optional[str] = None
+    expected_hours_year: Optional[float] = None
+    expected_hours_to_date: Optional[float] = None
+    expected_hours_week: Optional[float] = None
+    worked_hours_year: Optional[float] = None

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -108,3 +108,35 @@ def get_user_missing_scopes_token_headers(client: TestClient) -> Dict[str, str]:
     token = create_access_token(user)
     headers = {"Authorization": f"Bearer {token}"}
     return headers
+
+
+@pytest.fixture(scope="module")
+def get_admin_user_token_headers(client: TestClient) -> Dict[str, str]:
+    user = {
+        "aud": "account",
+        "roles": ["Admin User"],
+        "name": "RuPaul",
+        "preferred_username": "admin",
+        "given_name": "Paul",
+        "family_name": "Ru",
+        "email": "rupaul@dragrace.tv",
+    }
+    token = create_access_token(user)
+    headers = {"Authorization": f"Bearer {token}"}
+    return headers
+
+
+@pytest.fixture(scope="module")
+def get_manager_user_token_headers(client: TestClient) -> Dict[str, str]:
+    user = {
+        "aud": "account",
+        "roles": ["Manager User"],
+        "name": "Jean-Luc Picard",
+        "preferred_username": "manager",
+        "given_name": "Jean-Luc",
+        "family_name": "Picard",
+        "email": "jlp@enterprise-d.com",
+    }
+    token = create_access_token(user)
+    headers = {"Authorization": f"Bearer {token}"}
+    return headers

--- a/api/tests/helpers/test_time.py
+++ b/api/tests/helpers/test_time.py
@@ -1,6 +1,13 @@
 from datetime import datetime
 
-from api.helpers.time import total_hours_between_dates
+from api.helpers.time import (
+    total_hours_between_dates,
+    time_string_to_int,
+    int_to_time_string,
+    int_to_time_long_string,
+    vacation_int_to_string,
+    get_start_and_end_date_of_isoweek,
+)
 
 
 def test_total_hours_between_dates() -> None:
@@ -10,3 +17,36 @@ def test_total_hours_between_dates() -> None:
 
     # There are 10 weekdays in the period set above, so 10 * 8 == 80
     assert total_hours_between_dates(start_date, end_date, hours_per_weekday) == 80.0
+
+
+def test_time_string_to_int() -> None:
+    time_string = "4:30"
+
+    assert time_string_to_int(time_string) == 270
+
+
+def test_into_to_time_string() -> None:
+    time_minutes = 400
+
+    assert int_to_time_string(time_minutes) == "6:40"
+
+
+def test_int_to_time_long_string() -> None:
+    time_minutes = 870
+
+    assert int_to_time_long_string(time_minutes) == "14h 30m"
+
+
+def test_vacation_int_to_string() -> None:
+    time_minutes = 1285
+    user_capacity = 8.0
+
+    assert vacation_int_to_string(time_minutes, user_capacity) == "2 days, 5 h, 25 m (21h 25m)"
+
+
+def test_get_start_and_end_date_of_week() -> None:
+    current_date = datetime(2024, 1, 10)
+    start_and_end = get_start_and_end_date_of_isoweek(current_date)
+
+    assert start_and_end[0] == datetime(2024, 1, 7)
+    assert start_and_end[1] == datetime(2024, 1, 13)

--- a/api/tests/helpers/test_time.py
+++ b/api/tests/helpers/test_time.py
@@ -41,7 +41,7 @@ def test_vacation_int_to_string() -> None:
     time_minutes = 1285
     user_capacity = 8.0
 
-    assert vacation_int_to_string(time_minutes, user_capacity) == "2 days, 5 h, 25 m (21h 25m)"
+    assert vacation_int_to_string(time_minutes, user_capacity) == "2 days 5 h 25 m (21 h 25 m)"
 
 
 def test_get_start_and_end_date_of_week() -> None:

--- a/api/tests/utils/mock_data.py
+++ b/api/tests/utils/mock_data.py
@@ -4,9 +4,27 @@ from models.project import Project, ProjectAllocation, ProjectAssignment
 from models.timelog import Task, TaskType, Template
 from models.user import User, UserGroup, UserRoles
 from models.sector import Sector
+from models.config import Config
 
 
 DATA = [
+    (
+        Config,
+        [
+            {
+                "version": "3",
+                "block_tasks_by_time_enabled": False,
+                "block_tasks_by_time_number_of_days": 0,
+                "block_tasks_by_day_limit_enabled": False,
+                "block_tasks_by_day_limit_number_of_days": 0,
+                "block_tasks_by_date_enabled": False,
+                "block_tasks_by_date_date": "2000-01-01",
+                "vacation_project_id": 1,
+                "yearly_vacation_hours": 200,
+                "company_fte": 40,
+            }
+        ],
+    ),
     (
         User,
         [

--- a/api/tests/utils/mock_data.py
+++ b/api/tests/utils/mock_data.py
@@ -2,7 +2,7 @@ from models.area import Area
 from models.customer import Customer
 from models.project import Project, ProjectAllocation, ProjectAssignment
 from models.timelog import Task, TaskType, Template
-from models.user import User, UserGroup, UserRoles
+from models.user import User, UserGroup, UserRoles, UserCapacity
 from models.sector import Sector
 from models.config import Config
 
@@ -220,6 +220,24 @@ DATA = [
                 "user_id": 2,
                 "project_id": 2,
             },
+            {
+                "date": "2023-10-20",
+                "init": 1200,
+                "end": 1320,
+                "story": "that project",
+                "task_type": "project",
+                "description": "Managing that awesome project",
+                "user_id": 3,
+                "project_id": 2,
+            },
+        ],
+    ),
+    (
+        UserCapacity,
+        [
+            {"capacity": 8.00, "start": "2023-01-01", "end": "2023-12-31", "user_id": 1},
+            {"capacity": 6.00, "start": "2023-01-01", "end": "2023-12-31", "user_id": 2},
+            {"capacity": 8.00, "start": "2023-07-01", "end": "2023-12-31", "user_id": 3},
         ],
     ),
 ]

--- a/frontend/src/app/tasks/components/WorkSummaryPanel.tsx
+++ b/frontend/src/app/tasks/components/WorkSummaryPanel.tsx
@@ -1,0 +1,230 @@
+'use client'
+import { useState } from 'react';
+import Box from '@mui/joy/Box';
+import Stack from '@mui/joy/Stack';
+import AccordionGroup from '@mui/joy/AccordionGroup';
+import Accordion from '@mui/joy/Accordion'
+import AccordionDetails, { accordionDetailsClasses } from '@mui/joy/AccordionDetails';
+import AccordionSummary, { accordionSummaryClasses } from '@mui/joy/AccordionSummary';
+import Card from '@mui/joy/Card';
+import CardContent from '@mui/joy/CardContent'
+import Divider from '@mui/joy/Divider';
+import Table from '@mui/joy/Table';
+import { Tooltip } from '@mui/joy';
+import Avatar from '@mui/joy/Avatar'
+import List from '@mui/joy/List';
+import ListItem from '@mui/joy/ListItem';
+import ListItemContent from '@mui/joy/ListItemContent';
+import LinearProgress from '@mui/joy/LinearProgress';
+import Typography from '@mui/joy/Typography'
+import { Beach24Filled, AddSubtractCircle24Filled, CalendarDataBar24Regular, Info16Regular } from '@fluentui/react-icons';
+import { useGetWorkSummary } from '../hooks/useWorkSummary';
+import { useGetCurrentUser } from '@/hooks/useGetCurrentUser/useGetCurrentUser';
+import { getYear } from 'date-fns';
+
+type WorkSummaryProps = {
+  contentSidebarExpanded: boolean
+}
+
+const thisYear = getYear(new Date())
+
+export const WorkSummaryPanel = ({contentSidebarExpanded} : WorkSummaryProps) => {
+  const [index, setIndex] = useState<number | null>(0);
+  const summary = useGetWorkSummary()
+  const user = useGetCurrentUser()
+  const currentCapacity = user.capacities?.find(x => x.isCurrent)
+
+  return (
+       <AccordionGroup
+          variant="plain"
+          transition="0.2s"
+          sx={{
+            maxWidth: "fit-content",
+            borderRadius: 'md',
+          [`& .${accordionDetailsClasses.content}.${accordionDetailsClasses.expanded}`]:
+            {
+              paddingBlock: '1rem',
+            },
+          [`& .${accordionSummaryClasses.button}`]: {
+            paddingBlock: '1rem',
+          },
+          }}
+        >
+          <Accordion
+             expanded={index === 0 && contentSidebarExpanded}
+             onChange={(event, expanded) => {
+               setIndex(expanded ? 0 : null);
+             }}
+          >
+            <AccordionSummary>
+              <Avatar color="primary">
+                <CalendarDataBar24Regular />
+              </Avatar>
+              <ListItemContent>
+                <Typography level="title-md" noWrap={!contentSidebarExpanded}>Worked hours</Typography>
+                <Typography level="body-sm" noWrap={!contentSidebarExpanded}>
+                  View cumulative and segmented worked hours
+                </Typography>
+              </ListItemContent>
+            </AccordionSummary>
+            <AccordionDetails>
+              <List size="sm">
+                <ListItem>
+                  <ListItemContent sx={{fontWeight: 500}}>Today:</ListItemContent>
+                  <Typography level="body-sm">{summary?.todayText}</Typography>
+                </ListItem>
+                <ListItem>
+                  <ListItemContent sx={{fontWeight: 500}}>This week:</ListItemContent>
+                  <Typography level="body-sm">{summary?.weekText}</Typography>
+                </ListItem>
+              </List>
+              <Divider sx={{my: 1}} orientation='horizontal'/>
+              <Typography level="title-sm" sx={{my:1}}>Hours by project</Typography>
+              <Table aria-label="hours by project for today and current week" sx={{mt: 1, '& .vacation':{bgcolor: 'primary.softBg'} ,'& thead th:nth-child(1)': { width: '45%' }}}>
+                <thead>
+                  <tr>
+                    <th>Project</th>
+                    <th>Today</th>
+                    <th>Week</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {summary.projectSummaries?.map((projSummary) => (
+                    <tr key={projSummary.projectId} className={projSummary.isVacation ? "vacation": ""}>
+                      <td>{projSummary.project}</td>
+                      <td>{projSummary.todayText}</td>
+                      <td>{projSummary.weekText}</td>
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr>
+                    <th scope="row">Total</th>
+                    <th>{summary.todayText}</th>
+                    <th>{summary.weekText}</th>
+                  </tr>
+                </tfoot>
+              </Table>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion
+          expanded={index === 1 && contentSidebarExpanded}
+          onChange={(event, expanded) => {
+            setIndex(expanded ? 1 : null);
+          }}
+          >
+            <AccordionSummary>
+              <Avatar color="danger">
+                <AddSubtractCircle24Filled />
+              </Avatar>
+              <ListItemContent>
+                <Typography level="title-md" noWrap={!contentSidebarExpanded}>Over/under hours</Typography>
+                <Typography level="body-sm" noWrap={!contentSidebarExpanded}>
+                  Amount of hours ahead or behind expected
+                </Typography>
+              </ListItemContent>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography level="body-xs" sx={{p: 1.5, mx: 0.5, mb: 0.5}} variant="soft" color="primary">
+                Based on your capacity ({currentCapacity?.capacity } hours per day), you will have an expected number of hours to be worked for the week and year. The worked numbers below are calculated as of today.
+              </Typography>
+              <Stack direction="column" spacing={1} sx={{mt: 1}} justifyContent="space-between">
+                  <Divider>Week</Divider>
+                  <List size="sm">
+                  <ListItem>
+                    <ListItemContent sx={{fontWeight: 500}}>Worked:</ListItemContent>
+                    <Typography level="body-sm">{(summary?.week ?? 0) / 60} h</Typography>
+                  </ListItem>
+                  <ListItem>
+                    <ListItemContent sx={{fontWeight: 500}}>Expected:</ListItemContent>
+                    <Typography level="body-sm">{summary.expectedHoursWeek} h</Typography>
+                  </ListItem>
+                  <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Ahead/behind expected:</ListItemContent>
+                      <Typography level="body-sm">{((summary.week?? 0) /60) - (summary.expectedHoursWeek ?? 0)} h</Typography>
+                    </ListItem>
+                </List>
+                  <Divider>Year</Divider>
+                   <List size="sm">
+                    <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Worked:</ListItemContent>
+                      <Typography level="body-sm">{summary.workedHoursYear} h</Typography>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Total expected so far:</ListItemContent>
+                      <Typography level="body-sm">{summary.expectedHoursToDate} h</Typography>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Ahead/behind pace for year:</ListItemContent>
+                      <Typography level="body-sm">{(summary.workedHoursYear ?? 0) - (summary.expectedHoursToDate ?? 0)} h</Typography>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Total expected for year:</ListItemContent>
+                      <Typography level="body-sm">{summary.expectedHoursYear} h</Typography>
+                    </ListItem>
+                    <ListItem>
+                      <ListItemContent sx={{fontWeight: 500}}>Ahead/behind total for year:</ListItemContent>
+                      <Typography level="body-sm">{(summary.workedHoursYear ?? 0) - (summary.expectedHoursYear ?? 0)} h</Typography>
+                    </ListItem>
+                  </List>
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+          <Accordion
+            expanded={index === 2 && contentSidebarExpanded}
+            onChange={(event, expanded) => {
+              setIndex(expanded ? 2 : null);
+            }}
+          >
+            <AccordionSummary>
+                <Avatar color="success">
+                  <Beach24Filled/>
+                </Avatar>
+              <ListItemContent>
+                <Typography level="title-md" noWrap={!contentSidebarExpanded}>Vacation</Typography>
+                <Typography level="body-sm" noWrap={!contentSidebarExpanded}>View scheduled and available vacation</Typography>
+              </ListItemContent>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Card variant="soft" color="primary" invertedColors>
+                  <CardContent>
+                    <Typography level="title-lg">Available for {thisYear}</Typography>
+                    <Typography level="title-md">{summary.vacationAvailableText}</Typography>
+                  </CardContent>
+              </Card>
+              <Divider sx={{my: 1}} orientation='horizontal'>Status</Divider>
+              <Stack direction="column" spacing={1} sx={{mx: 0.5}}>
+                <Stack direction="row" spacing={1} sx={{my: 0.75}} justifyContent="space-between">
+                  <Typography level="title-sm">
+                    <Tooltip title="Vacation hours already used this year" variant="soft">
+                      <Info16Regular/>
+                    </Tooltip> Used:
+                  </Typography>
+                  <Typography level="body-sm">{summary.vacationUsedText}</Typography>
+                </Stack>
+                <LinearProgress variant="outlined" size="lg" color="primary" value={((summary.vacationUsed ?? 0) / (summary.vacationAvailable ?? 0)) * 100} determinate sx={{ my: 1 }} />
+                <Stack direction="row" spacing={1} sx={{my: 0.75}} justifyContent="space-between">
+                  <Typography level="title-sm">
+                    <Tooltip title="Vacation hours added to calendar and not yet used this year" variant="soft">
+                      <Info16Regular/>
+                    </Tooltip> Scheduled:
+                  </Typography>
+                  <Typography level="body-sm">{summary.vacationScheduledText}</Typography>
+                </Stack>
+                <LinearProgress variant="outlined" size="lg" color="neutral" value={((summary.vacationScheduled ?? 0) / (summary.vacationAvailable ?? 0)) * 100} determinate sx={{ my: 1 }} />
+                <Stack direction="row" spacing={1} sx={{my: 0.75}} justifyContent="space-between">
+                  <Typography level="title-sm">
+                    <Tooltip title="Vacation hours not used or scheduled" variant="soft">
+                      <Info16Regular/>
+                    </Tooltip> Pending:
+                  </Typography>
+                  <Typography level="body-sm">{summary.vacationPendingText}</Typography>
+                </Stack>
+                <LinearProgress variant="outlined" size="lg" color="neutral" value={((summary.vacationPending ?? 0) / (summary.vacationAvailable ?? 0)) * 100} determinate sx={{ my: 1 }} />
+              </Stack>
+            </AccordionDetails>
+          </Accordion>
+        </AccordionGroup>
+
+  )
+}

--- a/frontend/src/app/tasks/hooks/useCreateTask.ts
+++ b/frontend/src/app/tasks/hooks/useCreateTask.ts
@@ -22,6 +22,7 @@ export const useCreateTask = () => {
       onSuccess: (_, { handleSuccess }) => {
         handleSuccess()
         queryClient.invalidateQueries(['tasks', userId])
+        queryClient.invalidateQueries(['workSummary', userId])
         showSuccess('Task added succesfully')
         revalidateTag('tags')
       },

--- a/frontend/src/app/tasks/hooks/useDeleteTask.ts
+++ b/frontend/src/app/tasks/hooks/useDeleteTask.ts
@@ -17,7 +17,8 @@ export const useDeleteTask = () => {
       queryClient.setQueryData<Array<Task>>(['tasks', userId], (prevData) =>
         prevData!.filter((prevData) => prevData.id !== taskId)
       )
-      showSuccess('Task succesfully removed')
+      queryClient.invalidateQueries(['workSummary', userId])
+      showSuccess('Task successfully removed')
     },
     onError: () => {
       showError('Failed to remove task')

--- a/frontend/src/app/tasks/hooks/useEditTask.ts
+++ b/frontend/src/app/tasks/hooks/useEditTask.ts
@@ -28,7 +28,8 @@ export const useEditTask = ({ handleSuccess }: UseEditTaskProps) => {
           return task
         })
       )
-      showSuccess('Task succesfully edited')
+      queryClient.invalidateQueries(['workSummary', userId])
+      showSuccess('Task successfully edited')
       handleSuccess()
     },
     onError: (e) => {

--- a/frontend/src/app/tasks/hooks/useWorkSummary.ts
+++ b/frontend/src/app/tasks/hooks/useWorkSummary.ts
@@ -1,0 +1,21 @@
+import { useQuery  } from '@tanstack/react-query'
+import { useClientFetch } from '@/infra/lib/useClientFetch'
+import { makeGetWorkSummary } from '@/infra/workSummary/getWorkSummary'
+import { useGetCurrentUser } from '@/hooks/useGetCurrentUser/useGetCurrentUser'
+import { WorkSummary } from '@/domain/WorkSummary'
+
+export const useGetWorkSummary = () => {
+  const apiClient = useClientFetch()
+  const { id: userId } = useGetCurrentUser()
+  const getWorkSummary = makeGetWorkSummary(apiClient)
+
+  const { data } = useQuery({
+    queryKey: ['workSummary', userId],
+    queryFn: () => getWorkSummary(),
+    initialData: []
+  })
+  if (!data) {
+    return {} as WorkSummary
+  }
+  return data
+}

--- a/frontend/src/app/tasks/layout.tsx
+++ b/frontend/src/app/tasks/layout.tsx
@@ -1,44 +1,62 @@
 'use client'
+import { useState } from 'react'
 
 import { PropsWithChildren } from 'react'
 import { Tabs, TabList, Tab, Box } from '@mui/joy'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { ContentSidebar } from '@/ui/ContentSidebar/ContentSidebar'
+import { WorkSummaryPanel } from '@/app/tasks/components/WorkSummaryPanel';
+
 
 export default function TasksLayout({ children }: PropsWithChildren) {
+  const [contentBarExpanded, setContentBarExpanded] = useState(false)
+
   const pathname = usePathname()
 
   return (
     <Box
       sx={{
-        display: 'flex',
-        padding: { xs: '0 8px', sm: '0' },
-        gridTemplateRows: '33px 1fr',
-        margin: '0 auto',
-        minHeight: 'calc(100vh - 30px)',
-        rowGap: '16px',
-        flexDirection: 'column'
+        margin: '0 60px 0 auto'
       }}
     >
-      <Box sx={{ maxWidth: '1146px', margin: '0 auto', width: '100%' }}>
-        <Tabs
-          sx={{
-            borderRadius: '8px',
-            border: '1px solid #C4C6D0',
-            width: 'fit-content',
-            paddding: '1px'
-          }}
-          size="md"
-          value={pathname}
-        >
-          <TabList disableUnderline>
-            <TimeViewTab path="/tasks">Day</TimeViewTab>
-            <TimeViewTab path="/tasks/week">Week</TimeViewTab>
-            <TimeViewTab path="/tasks/month">Month</TimeViewTab>
-          </TabList>
-        </Tabs>
+      <Box
+        sx={{
+          display: 'flex',
+          padding: { xs: '0 8px', sm: '0' },
+          gridTemplateRows: '33px 1fr',
+          margin: '0 auto',
+          minHeight: 'calc(100vh - 30px)',
+          rowGap: '16px',
+          flexDirection: 'column'
+        }}
+      >
+        <Box sx={{ maxWidth: '1146px', margin: '0 auto', width: '100%' }}>
+          <Tabs
+            sx={{
+              borderRadius: '8px',
+              border: '1px solid #C4C6D0',
+              width: 'fit-content',
+              padding: '1px'
+            }}
+            size="md"
+            value={pathname}
+          >
+            <TabList disableUnderline>
+              <TimeViewTab path="/tasks">Day</TimeViewTab>
+              <TimeViewTab path="/tasks/week">Week</TimeViewTab>
+              <TimeViewTab path="/tasks/month">Month</TimeViewTab>
+            </TabList>
+          </Tabs>
+        </Box>
+        {children}
       </Box>
-      {children}
+      <ContentSidebar
+        expanded={contentBarExpanded}
+        toggleContentBar={() => setContentBarExpanded((prevState) => !prevState)}
+      >
+        <WorkSummaryPanel contentSidebarExpanded={contentBarExpanded}/>
+      </ContentSidebar>
     </Box>
   )
 }

--- a/frontend/src/domain/WorkSummary.ts
+++ b/frontend/src/domain/WorkSummary.ts
@@ -1,0 +1,30 @@
+
+export type WorkSummary = {
+  today?: number | null
+  week?: number | null
+  todayText: string
+  weekText: string
+  projectSummaries?: Array<ProjectTaskSummary> | null
+  vacationAvailable: number
+  vacationAvailableText: string
+  vacationScheduled: number
+  vacationScheduledText: string
+  vacationPending: number
+  vacationPendingText: string
+  vacationUsed: number
+  vacationUsedText: string
+  expectedHoursYear: number
+  expectedHoursToDate: number
+  expectedHoursWeek: number
+  workedHoursYear: number
+}
+
+export type ProjectTaskSummary = {
+  projectId: number
+  project: string
+  todayTotal: string
+  todayText: string
+  weekTotal: string
+  weekText: string
+  isVacation: boolean
+}

--- a/frontend/src/infra/workSummary/getWorkSummary.ts
+++ b/frontend/src/infra/workSummary/getWorkSummary.ts
@@ -1,0 +1,12 @@
+import { ApiClient } from '@/infra/lib/apiClient'
+import { WorkSummary } from '@/domain/WorkSummary';
+
+export const makeGetWorkSummary = (apiClient: ApiClient) => async (): Promise<WorkSummary> => {
+  const response = await apiClient(`/v1/timelog/summary`)
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch Work Summary')
+  }
+
+  return await response.json()
+}

--- a/frontend/src/ui/BaseLayout/BaseLayout.tsx
+++ b/frontend/src/ui/BaseLayout/BaseLayout.tsx
@@ -1,15 +1,12 @@
 'use client'
 import { useState } from 'react'
 import { styled } from '@mui/joy/styles'
-
 import { Sidebar } from '@/ui/Sidebar/Sidebar'
-import { ContentSidebar } from '@/ui/ContentSidebar/ContentSidebar'
 import { Alert } from '@/ui/Alert/Alert'
+
 
 export const BaseLayout = ({ children }: { children: React.ReactNode }) => {
   const [navBarExpanded, setNavBarExpanded] = useState(false)
-  const [contentBarExpanded, setContentBarExpanded] = useState(false)
-
   return (
     <>
       <SkipNavigation href="#main-content">Skip Navigation</SkipNavigation>
@@ -21,7 +18,6 @@ export const BaseLayout = ({ children }: { children: React.ReactNode }) => {
         sx={{
           transition: 'margin .6s',
           ml: { sm: navBarExpanded ? '336px' : '73px' },
-          mr: { sm: contentBarExpanded ? '320px' : '60px' },
           mt: { xs: navBarExpanded ? '280px' : '73px', sm: '0' }
         }}
         id="main-content"
@@ -29,12 +25,6 @@ export const BaseLayout = ({ children }: { children: React.ReactNode }) => {
       >
         {children}
       </Main>
-      <ContentSidebar
-        expanded={contentBarExpanded}
-        toggleContentBar={() => setContentBarExpanded((prevState) => !prevState)}
-      >
-        <div style={{ color: 'black' }}>Right Sidebar</div>
-      </ContentSidebar>
       <Alert />
     </>
   )

--- a/frontend/src/ui/CollapseButton/CollapseButton.tsx
+++ b/frontend/src/ui/CollapseButton/CollapseButton.tsx
@@ -13,11 +13,12 @@ type CollapseButtonProps = {
 export const CollapseButton = ({ onClick, sx, iconSx }: CollapseButtonProps) => {
   return (
     <Button
+      variant="soft"
+      color="neutral"
       size="sm"
       onClick={onClick}
       sx={{
         borderRadius: '50%',
-        bgcolor: 'white',
         width: 32,
         height: 32,
         alignItems: 'center',

--- a/frontend/src/ui/ContentSidebar/ContentSidebar.tsx
+++ b/frontend/src/ui/ContentSidebar/ContentSidebar.tsx
@@ -13,7 +13,7 @@ export const ContentSidebar = ({ children, expanded, toggleContentBar }: Content
   return (
     <Box
       sx={{
-        height: { xs: expanded ? '60px' : '320px', sm: '100vh' },
+        height: { xs: expanded ? '50vh' : '33px', sm: '100vh' },
         width: { xs: '100vw', sm: expanded ? '320px' : '60px' },
         transition: { xs: 'height 0.6s', sm: 'width 0.6s' },
         bgcolor: 'white',
@@ -21,15 +21,18 @@ export const ContentSidebar = ({ children, expanded, toggleContentBar }: Content
         position: { xs: 'relative', sm: 'fixed' },
         zIndex: 1,
         top: { xs: 'unset', sm: '0' },
-        right: 0
+        right: 0,
+        overflowY: 'auto',
+        overflowX: 'hidden'
       }}
     >
       <CollapseButton
         sx={{
-          left: { xs: '0px', sm: '-16px' },
-          right: { xs: '0px', sm: 'unset' },
-          top: { xs: '-16px', sm: '61px' },
-          margin: '0 auto'
+          borderRadius: 0,
+          margin: '0 auto',
+          width: '100%',
+          position: 'unset',
+          boxShadow: '0px 2px 4px #00000029',
         }}
         iconSx={{
           transform: { xs: 'rotateZ(90deg)', sm: 'rotateZ(180deg)' },

--- a/frontend/src/ui/Sidebar/DarkModeSwitch.tsx
+++ b/frontend/src/ui/Sidebar/DarkModeSwitch.tsx
@@ -16,7 +16,7 @@ type SwitchComponentProps = {
 }
 
 const TrackText = ({ icon: Icon, children, sx }: SwitchComponentProps) => (
-  <Box sx={{ display: { xs: 'none', sm: 'flex' }, alignItems: 'center', gap: '24px', ...sx }}>
+  <Box sx={{ display: { xs: 'none'}, alignItems: 'center', gap: '24px', ...sx }}>
     <Icon color="#00396d" />
     <Typography sx={{ color: '#b3cfe9' }}>{children}</Typography>
   </Box>
@@ -36,7 +36,7 @@ const SwitchThumb = ({ icon: Icon, children }: SwitchComponentProps) => (
     }}
   >
     <Icon color="#b3cfe9" />
-    <Typography sx={{ display: { xs: 'none', sm: 'block' }, color: '#F0F3F7' }}>
+    <Typography sx={{ display: { xs: 'none'}, color: '#F0F3F7' }}>
       {children}
     </Typography>
   </Box>
@@ -83,12 +83,12 @@ export const DarkModeSwitch = ({ sx }: DarkModeSwitchProps) => {
             '--Switch-trackBackground': '#030D1A'
           }
         },
-        '--Switch-thumbWidth': { xs: '40px', sm: '148px' },
-        '--Switch-thumbSize': { xs: '20px', sm: '30px' },
-        '--Switch-trackWidth': { xs: '60px', sm: '260px' },
-        '--Switch-thumbRadius': { xs: '', sm: '20px' },
-        '--Switch-trackHeight': { xs: '', sm: '40px' },
-        '--Switch-trackRadius': { xs: '', sm: '25px' },
+        '--Switch-thumbWidth': { xs: '40px'},
+        '--Switch-thumbSize': { xs: '20px' },
+        '--Switch-trackWidth': { xs: '60px' },
+        '--Switch-thumbRadius': { xs: '' },
+        '--Switch-trackHeight': { xs: '' },
+        '--Switch-trackRadius': { xs: '' },
         ...sx
       }}
     />

--- a/frontend/src/ui/Sidebar/Sidebar.tsx
+++ b/frontend/src/ui/Sidebar/Sidebar.tsx
@@ -82,6 +82,7 @@ export const Sidebar = ({ expanded, toggleSidebar }: SidebarProps) => {
             transition: 'transform 0.6s',
             transformOrigin: '20px',
             mr: '4px',
+            mb: '9px',
             gridArea: 'switch',
             ...(!expanded && {
               transform: { sm: 'rotate(-90deg)' }


### PR DESCRIPTION
The work summary panel will be visible only from the tasks area and show the user some basic information about the time they have worked for today and the week, as well as vacation time and extra hours. This information is shown in the current version of the application on the left side of the app. Some small improvements have been made here, such as breaking down the worked hours by project for a user and adding tooltips to explain each vacation category (used, scheduled, pending). 

A few small UI changes have been made here, as well. The collapse button for the right panel has been modified to be within the panel instead of a floating button. The dark/light mode toggle has been made smaller on the desktop view (same as it appears on mobile).

This is a first version of the component and it might be nice to display the time per project from the 'Worked Hours' panel as a pie chart instead of (or in addition to?) the table. Another planned feature for the 'Vacation' panel would be to add a calendar that shows upcoming vacation at a glance. 

[Screencast from 2024-01-24 10-34-25.webm](https://github.com/Igalia/phpreport/assets/3666105/24a7223c-c33e-4757-9215-0fc324f0fbc3)


