### PR TITLE
Refactor rest of infra

### DIFF
--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,7 @@
 import NextAuth, { NextAuthOptions } from 'next-auth'
 import KeycloakProvider from 'next-auth/providers/keycloak'
 import { fetchFactory } from '@/infra/lib/apiClient'
-import { getCurrentUser } from '@/infra/user/getCurrentUser'
+import { makeGetCurrentUser } from '@/infra/user/getCurrentUser'
 import { JWT } from 'next-auth/jwt'
 
 /**
@@ -86,7 +86,8 @@ export const authOptions: NextAuthOptions = {
 
         const apiClient = fetchFactory({ baseURL: process.env.API_BASE!, token: token.accessToken })
 
-        const user = await getCurrentUser(apiClient)
+        const getCurrentUser = makeGetCurrentUser(apiClient)
+        const user = await getCurrentUser()
 
         token.user = user
       }

--- a/frontend/src/app/planner/page.tsx
+++ b/frontend/src/app/planner/page.tsx
@@ -1,11 +1,12 @@
-import { getProjects } from '@/infra/project/getProjects'
+import { makeGetProjects } from '@/infra/project/getProjects'
 import { serverFetch } from '@/infra/lib/serverFetch'
 import { ProjectSelection } from './components/ProjectSelection'
 
 const getPageData = async () => {
   const apiClient = await serverFetch()
+  const getProjects = makeGetProjects(apiClient)
 
-  return getProjects(apiClient)
+  return getProjects()
 }
 
 export default async function ProjectManagement() {

--- a/frontend/src/app/tasks/hooks/useDeleteTask.ts
+++ b/frontend/src/app/tasks/hooks/useDeleteTask.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Task } from '@/domain/Task'
 import { useAlert } from '@/ui/Alert/useAlert'
-import { deleteTask } from '@/infra/task/deleteTask'
+import { makeDeleteTask } from '@/infra/task/deleteTask'
 import { useClientFetch } from '@/infra/lib/useClientFetch'
 import { useGetCurrentUser } from '@/hooks/useGetCurrentUser/useGetCurrentUser'
 
@@ -10,8 +10,9 @@ export const useDeleteTask = () => {
   const queryClient = useQueryClient()
   const { id: userId } = useGetCurrentUser()
   const { showError, showSuccess } = useAlert()
+  const deleteTask = makeDeleteTask(apiClient)
 
-  const { mutate } = useMutation((taskId: number) => deleteTask(taskId, apiClient), {
+  const { mutate } = useMutation((taskId: number) => deleteTask(taskId), {
     onSuccess: (_, taskId) => {
       queryClient.setQueryData<Array<Task>>(['tasks', userId], (prevData) =>
         prevData!.filter((prevData) => prevData.id !== taskId)

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -1,21 +1,21 @@
 import { DayView } from './DayView'
-import { getProjects } from '@/infra/project/getProjects'
-import { getTaskTypes } from '@/infra/taskType/getTaskTypes'
+import { makeGetProjects } from '@/infra/project/getProjects'
+import { makeGetTaskTypes } from '@/infra/taskType/getTaskTypes'
+import { makeGetTemplates } from '@/infra/template/getTemplates'
 import { serverFetch } from '@/infra/lib/serverFetch'
 import { authOptions } from '@/app/api/auth/[...nextauth]/route'
 import { getServerSession } from 'next-auth'
-import { getTemplates } from '@/infra/template/getTemplates'
 
 const getPageData = async () => {
   const apiClient = await serverFetch()
   const session = await getServerSession(authOptions)
   const { id: userId } = session!.user
 
-  return await Promise.all([
-    getProjects(apiClient),
-    getTaskTypes(apiClient),
-    getTemplates(apiClient, { userId })
-  ])
+  const getProjects = makeGetProjects(apiClient)
+  const getTaskTypes = makeGetTaskTypes(apiClient)
+  const getTemplates = makeGetTemplates(apiClient)
+
+  return await Promise.all([getProjects(), getTaskTypes(), getTemplates({ userId })])
 }
 
 export default async function Tasks() {

--- a/frontend/src/infra/project/getProjects.ts
+++ b/frontend/src/infra/project/getProjects.ts
@@ -1,7 +1,7 @@
 import { ApiClient } from '@/infra/lib/apiClient'
 import { Project } from '@/domain/Project'
 
-export const getProjects = async (apiClient: ApiClient): Promise<Array<Project>> => {
+export const makeGetProjects = (apiClient: ApiClient) => async (): Promise<Array<Project>> => {
   const response = await apiClient('/v1/projects/')
 
   if (!response.ok) {

--- a/frontend/src/infra/task/deleteTask.ts
+++ b/frontend/src/infra/task/deleteTask.ts
@@ -1,17 +1,20 @@
 import { ApiClient } from '../lib/apiClient'
+import { Task } from '@/domain/Task'
 
-export const deleteTask = async (taskId: number, apiClient: ApiClient): Promise<string> => {
-  return apiClient(`/v1/timelog/tasks/${taskId}`, {
-    method: 'DELETE'
-  })
-    .then((response) => {
+export const makeDeleteTask =
+  (apiClient: ApiClient) =>
+  async (taskId: Task['id']): Promise<string> => {
+    try {
+      const response = await apiClient(`/v1/timelog/tasks/${taskId}`, {
+        method: 'DELETE'
+      })
+
       if (!response.ok) {
         throw Error(response.statusText)
       }
 
       return response.statusText
-    })
-    .catch((e) => {
-      throw new Error(e)
-    })
-}
+    } catch (e) {
+      throw e
+    }
+  }

--- a/frontend/src/infra/taskType/getTaskTypes.ts
+++ b/frontend/src/infra/taskType/getTaskTypes.ts
@@ -1,7 +1,7 @@
 import { ApiClient } from '@/infra/lib/apiClient'
 import { TaskType } from '@/domain/TaskType'
 
-export const getTaskTypes = async (apiClient: ApiClient): Promise<Array<TaskType>> => {
+export const makeGetTaskTypes = (apiClient: ApiClient) => async (): Promise<Array<TaskType>> => {
   const response = await apiClient('/v1/timelog/task_types/')
 
   if (!response.ok) {

--- a/frontend/src/infra/template/getTemplates.ts
+++ b/frontend/src/infra/template/getTemplates.ts
@@ -1,18 +1,18 @@
 import { Template } from '@/domain/Template'
 import { ApiClient } from '../lib/apiClient'
+import { User } from '@/domain/User'
 
-export const getTemplates = async (
-  apiClient: ApiClient,
-  { userId }: { userId: number }
-): Promise<Array<Template>> => {
-  const params = new URLSearchParams({ user_id: userId.toString() })
-  const response = await apiClient(`/v1/timelog/templates?${params}`, {
-    next: { tags: ['templates'] }
-  })
+export const makeGetTemplates =
+  (apiClient: ApiClient) =>
+  async ({ userId }: { userId: User['id'] }): Promise<Array<Template>> => {
+    const params = new URLSearchParams({ user_id: userId.toString() })
+    const response = await apiClient(`/v1/timelog/templates?${params}`, {
+      next: { tags: ['templates'] }
+    })
 
-  if (!response.ok) {
-    throw new Error('Failed to fetch Templates')
+    if (!response.ok) {
+      throw new Error('Failed to fetch Templates')
+    }
+
+    return await response.json()
   }
-
-  return await response.json()
-}

--- a/frontend/src/infra/user/getCurrentUser.ts
+++ b/frontend/src/infra/user/getCurrentUser.ts
@@ -1,7 +1,7 @@
 import { User } from '@/domain/User'
 import { ApiClient } from '../lib/apiClient'
 
-export const getCurrentUser = async (apiClient: ApiClient): Promise<User> => {
+export const makeGetCurrentUser = (apiClient: ApiClient) => async (): Promise<User> => {
   const response = await apiClient('/v1/users/me')
 
   if (!response.ok) {


### PR DESCRIPTION
This PR changes the rest of the files in /infra to use the factory pattern:
```ts
// from
getSomething = async (apiClient: apiClient) => {}

// to
makeGetSomething = (apiClient: apiClient) => async () => {}
```

This change is to ensure that all functions that depend on an apiClient will receive the argument the same way, to make it standardized.