### PR TITLE
patch: Add envs for port and host, fix endpoint

### DIFF
--- a/api/migrations/versions/6a1ad39b566d_add_calculation_functions.py
+++ b/api/migrations/versions/6a1ad39b566d_add_calculation_functions.py
@@ -1,7 +1,7 @@
 """Add calculation functions
 
 Revision ID: 6a1ad39b566d
-Revises: 2ac6108453f3
+Revises: cf4f31d5cd2d
 Create Date: 2024-01-05 11:07:57.026492
 
 """

--- a/docker/prod.frontend.Dockerfile
+++ b/docker/prod.frontend.Dockerfile
@@ -42,5 +42,9 @@ USER nextjs
 
 EXPOSE 3000
 
+ENV PORT 3000
+# set hostname to localhost
+ENV HOSTNAME "0.0.0.0"
+
 CMD ["node", "server.js"]
 

--- a/frontend/src/infra/taskType/getTaskTypes.ts
+++ b/frontend/src/infra/taskType/getTaskTypes.ts
@@ -2,7 +2,7 @@ import { ApiClient } from '@/infra/lib/apiClient'
 import { TaskType } from '@/domain/TaskType'
 
 export const makeGetTaskTypes = (apiClient: ApiClient) => async (): Promise<Array<TaskType>> => {
-  const response = await apiClient('/v1/timelog/task_types/')
+  const response = await apiClient('/v1/timelog/task_types')
 
   if (!response.ok) {
     throw new Error('Failed to fetch TaskTypes')


### PR DESCRIPTION
This PR contains 2 small patches to fix errors found on deployment.

- Not specifying the port/hostname as env values in frontend image works when running locally but fails in a production environment
- Fix task type endpoint