### PR TITLE
Use scheduled hours instead of used for percentage

### DIFF
--- a/model/facade/action/GetHolidaySummaryReportAction.php
+++ b/model/facade/action/GetHolidaySummaryReportAction.php
@@ -94,7 +94,7 @@ class GetHolidaySummaryReportAction extends GetHolidayHoursBaseAction
             'usedHours' => round($usedHours, 2),
             'pendingHours' => round($summary['pendingHours'][$this->user->getLogin()], 2),
             'scheduledHours' => round($summary['scheduledHours'][$this->user->getLogin()] - $usedHours, 2),
-            'percentage' =>  $summary['availableHours'][$this->user->getLogin()] ? round(($usedHours / $summary['availableHours'][$this->user->getLogin()]) * 100, 2) : 0,
+            'percentage' =>  $summary['availableHours'][$this->user->getLogin()] ? round(($summary['scheduledHours'][$this->user->getLogin()] / $summary['availableHours'][$this->user->getLogin()]) * 100, 2) : 0,
             'hoursDay' => $validJourney,
             'holidays' => $leaves,
         ];


### PR DESCRIPTION
Used hours are only for scheduled hours that are in the past. To calculate percentage it is needed to use all the scheduled hours for the period instead.